### PR TITLE
[feat] projectの移動でissueにラベル付けするCI

### DIFF
--- a/.github/workflows/label-progress.yml
+++ b/.github/workflows/label-progress.yml
@@ -1,0 +1,14 @@
+name: Label when moved to In Progress
+
+on:
+  project_card:
+    types: [moved]
+
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 'in-progress' label
+        # プロジェクトのステータスが 'In Progress' になった時のみ実行するロジックをここに書きます
+        # ※ 実際には 'actions/github-script' などを使って
+        # ステータス名を判定し、Issueにラベルを貼る処理を記述します。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更の主目的
- プロジェクトカードが「In Progress」ステータスに移動された時に、対応するIssueに「in-progress」ラベルを自動的に付けるGitHub Actionsワークフローの基盤構築
- プロジェクト進捗管理とIssue管理の自動連携を実現

## 影響範囲
- **新規追加ファイル**
  - `.github/workflows/label-progress.yml`：GitHub Actionsワークフロー定義ファイル

## 実装状況
- ワークフローの基本骨組みは完成（トリガー条件、ジョブ定義）
- 実際のラベル付けロジックはコメントのみで、実装は未完了（`actions/github-script`などを使用した処理が必要）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->