### PR TITLE
fix: disable scheduled project sync due to missing PROJECT_TOKEN

### DIFF
--- a/.github/workflows/label-progress.yml
+++ b/.github/workflows/label-progress.yml
@@ -1,8 +1,11 @@
 name: Auto Label on Project Status Change
 
 on:
-  schedule:
-    - cron: '*/30 * * * *'
+  # NOTE: PROJECT_TOKEN シークレットが設定されていないため、スケジュール実行を無効化しています。
+  # GitHub Projects V2 へのアクセスには、project権限を持つPATが必要です。
+  # PATを設定後、以下のscheduleをアンコメントしてください：
+  # schedule:
+  #   - cron: '*/30 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
GitHub Projects V2 requires a Personal Access Token with 'project' scope. The default GITHUB_TOKEN does not have this permission. Disabled scheduled runs until PROJECT_TOKEN is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 概要

### 変更の主目的
- GitHub Projects V2 へのアクセスに必要な `PROJECT_TOKEN`（project スコープ付き PAT）が未設定であるため、スケジュール実行を無効化
- デフォルトの `GITHUB_TOKEN` では project スコープが不足しており、自動実行されるプロジェクト同期が失敗するのを防止

### 影響範囲
- **修正ファイル**: `.github/workflows/label-progress.yml`
- **変更内容**:
  - `schedule:` トリガーを削除（スケジュール自動実行を無効化）
  - PROJECT_TOKEN 未設定の理由と設定後の対応方法を日本語コメントで記載
  - アンコメント用の schedule 設定例をガイダンスとして提供
  - `workflow_dispatch:` トリガーは保持（手動実行は可能）
  - github-token に `${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}` のフォールバック処理を設定済み

### 実装ステータス
- ワークフロー自体のロジック変更はなし
- スケジュール実行のみを無効化し、設定待機中の状態へ
<!-- end of auto-generated comment: release notes by coderabbit.ai -->