### PR TITLE
fix: simplify GraphQL query for personal user projects

### DIFF
--- a/.github/workflows/label-progress.yml
+++ b/.github/workflows/label-progress.yml
@@ -1,11 +1,8 @@
 name: Auto Label on Project Status Change
 
 on:
-  # NOTE: PROJECT_TOKEN シークレットが設定されていないため、スケジュール実行を無効化しています。
-  # GitHub Projects V2 へのアクセスには、project権限を持つPATが必要です。
-  # PATを設定後、以下のscheduleをアンコメントしてください：
-  # schedule:
-  #   - cron: '*/30 * * * *'
+  schedule:
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -25,42 +22,11 @@ jobs:
             const PROJECT_NUMBER = 1; 
             const OWNER = context.repo.owner;
 
+            // 個人ユーザーのプロジェクトのみを取得するクエリ
+            // （organizationクエリを含めるとNOT_FOUNDエラーが発生するため削除）
             const query = `
               query($owner: String!, $number: Int!) {
                 user(login: $owner) {
-                  projectV2(number: $number) {
-                    items(first: 100) {
-                      nodes {
-                        id
-                        content {
-                          ... on Issue {
-                            id
-                            number
-                            repository {
-                              name
-                              owner {
-                                login
-                              }
-                            }
-                          }
-                        }
-                        fieldValues(first: 20) {
-                          nodes {
-                            ... on ProjectV2ItemFieldSingleSelectValue {
-                              name
-                              field {
-                                ... on ProjectV2FieldCommon {
-                                  name
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-                organization(login: $owner) {
                   projectV2(number: $number) {
                     items(first: 100) {
                       nodes {
@@ -99,11 +65,12 @@ jobs:
             try {
               const result = await github.graphql(query, { owner: OWNER, number: PROJECT_NUMBER });
               
-              // UserまたはOrgからプロジェクトを取得
-              const project = (result.user && result.user.projectV2) || (result.organization && result.organization.projectV2);
+              // ユーザープロジェクトを取得
+              const project = result.user && result.user.projectV2;
               
               if (!project) {
-                console.error(`Project not found: ${OWNER}/projects/${PROJECT_NUMBER}`);
+                console.log(`Project not found: ${OWNER}/projects/${PROJECT_NUMBER}`);
+                console.log('This is expected if no project exists or permissions are insufficient.');
                 return;
               }
 
@@ -132,6 +99,8 @@ jobs:
                   }
                 }
               }
+              
+              console.log('Synchronization completed successfully.');
             } catch (error) {
               console.error("Error during synchronization:", error);
               core.setFailed(error.message);


### PR DESCRIPTION
Remove organization query that causes NOT_FOUND error for personal accounts. Re-enable scheduled execution now that Classic PAT with project scope is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 変更の主目的

個人ユーザーアカウントで GraphQL クエリが組織プロジェクトを検索していたことが原因の NOT_FOUND エラーを解決するため、クエリを個人プロジェクトのみに限定しました。また、Classic PAT with project scope の設定が完了したため、ワークフローのスケジュール実行を再度有効化しました。

## 影響範囲

**変更ファイル**: `.github/workflows/label-progress.yml`

### 詳細な変更内容

- **スケジュール実行トリガー**: スケジュール実行を無効化するコメントを削除し、cron スケジュール設定を復活
- **GraphQL クエリの簡素化**: 
  - 組織プロジェクトの検索ロジックを削除
  - `user.projectV2` のみを対象に絞込
- **プロジェクト取得ロジック**:
  - フォールバック処理（`organization.projectV2` への参照）を削除
  - ユーザープロジェクトのメイン取得パスに統一
- **エラーハンドリング**:
  - プロジェクト未検出時のログを、エラー扱いから情報ログに変更
  - パーミッション不足やプロジェクト未作成の状況では想定される挙動として扱う
- **ログ出力の強化**: 同期完了メッセージを追加

**コード量**: +10/-41 行（削減傾向）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->