### PR TITLE
UI改善step2

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,11 +74,11 @@
 
 共同作業であることを明示するため、AIエージェントがコミットするときは、コミットメッセージの末尾に次の`Co-authored-byトレーラー`を加えてどのAIエージェントが作業したか分かるようにしてください。
 
-- Co-Authored-By: gemini <39171201+gemini-cli@users.noreply.github.com>
+- Co-Authored-By: gemini <218195315+gemini-cli@users.noreply.github.com>
 
-Claude modelの場合は以下でも良いです
+Claude modelの場合は以下でお願いします
 
-- Co-authored-by: claude[bot] <39171201+claude[bot]@users.noreply.github.com>
+- Co-authored-by: anthropic-claude[bot] <145262791+anthropic-claude[bot]@users.noreply.github.com>
 
 
 ## コマンド操作について

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,7 +74,12 @@
 
 共同作業であることを明示するため、AIエージェントがコミットするときは、コミットメッセージの末尾に次の`Co-authored-byトレーラー`を加えてどのAIエージェントが作業したか分かるようにしてください。
 
-- Co-Authored-By: gemini <218195315+gemini-cli@users.noreply.github.com>
+- Co-Authored-By: gemini <gemini-cli@users.noreply.github.com>
+
+Claude modelの場合は以下でも良いです
+
+- Co-Authored-By: claude <noreply@anthropic.com>
+
 
 ## コマンド操作について
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -84,10 +84,6 @@ geminiの場合は以下でお願いします
 
 - Co-Authored-By: gemini <218195315+gemini-cli@users.noreply.github.com>
 
-Claude modelの場合は以下でお願いします
-
-- Co-authored-by: anthropic-claude[bot] <145262791+anthropic-claude[bot]@users.noreply.github.com>
-
 
 ## コマンド操作について
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,11 +74,11 @@
 
 共同作業であることを明示するため、AIエージェントがコミットするときは、コミットメッセージの末尾に次の`Co-authored-byトレーラー`を加えてどのAIエージェントが作業したか分かるようにしてください。
 
-- Co-Authored-By: gemini <gemini-cli@users.noreply.github.com>
+- Co-Authored-By: gemini <39171201+gemini-cli@users.noreply.github.com>
 
 Claude modelの場合は以下でも良いです
 
-- Co-Authored-By: claude <noreply@anthropic.com>
+- Co-authored-by: claude[bot] <39171201+claude[bot]@users.noreply.github.com>
 
 
 ## コマンド操作について

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -73,6 +73,14 @@
 ## コミットルール
 
 共同作業であることを明示するため、AIエージェントがコミットするときは、コミットメッセージの末尾に次の`Co-authored-byトレーラー`を加えてどのAIエージェントが作業したか分かるようにしてください。
+空行を挟んでください。
+```
+feat: commit message
+
+Co-Authored-By: gemini <218195315+gemini-cli@users.noreply.github.com>
+```
+
+geminiの場合は以下でお願いします
 
 - Co-Authored-By: gemini <218195315+gemini-cli@users.noreply.github.com>
 

--- a/backend/src/app/api/chats/[id]/route.ts
+++ b/backend/src/app/api/chats/[id]/route.ts
@@ -19,7 +19,9 @@ export async function GET(
     try {
         const { id } = await params;
         const url = new URL(req.url);
-        const take = Math.min(Number(url.searchParams.get('take') || '20'), 100);
+        const rawTake = parseInt(url.searchParams.get('take') ?? '20', 10);
+        const parsedTake = (Number.isNaN(rawTake) || !Number.isFinite(rawTake)) ? 20 : rawTake;
+        const take = Math.min(Math.max(parsedTake, 1), 100);
         const cursor = url.searchParams.get('cursor') || undefined;
 
         const chat = await prisma.chat.findUnique({

--- a/backend/src/app/api/chats/[id]/route.ts
+++ b/backend/src/app/api/chats/[id]/route.ts
@@ -5,6 +5,12 @@ import { getLatestStatus, flattenStatus } from "@/lib/persona";
 
 /**
  * 特定のチャット（セッション）のログを取得します
+ * 
+ * クエリパラメータ:
+ * - take: 取得件数 (デフォルト: 20)
+ * - cursor: カーソル（chatLogのid）。指定した場合、そのidより古いログを取得する
+ * 
+ * レスポンスには hasMore（追加データ有無）と nextCursor（次回取得用カーソル）を含む
  */
 export async function GET(
     req: NextRequest,
@@ -12,41 +18,75 @@ export async function GET(
 ) {
     try {
         const { id } = await params;
+        const url = new URL(req.url);
+        const take = Math.min(Number(url.searchParams.get('take') || '20'), 100);
+        const cursor = url.searchParams.get('cursor') || undefined;
 
         const chat = await prisma.chat.findUnique({
             where: { id },
-            include: {
-                chatLogs: {
-                    orderBy: { createdAt: 'asc' }
-                }
-            }
+            select: { id: true, title: true, personaId: true, createdAt: true, updatedAt: true }
         });
 
         if (!chat) {
             return NextResponse.json({ error: "Chat not found" }, { status: 404 });
         }
 
-        // このチャットに関連するペルソナの最新の内省結果を取得
-        const latestReflection = await prisma.reflectionEvent.findFirst({
-            where: { personaId: chat.personaId },
-            orderBy: { createdAt: 'desc' }
+        // カーソルベースのページネーションでチャットログを取得
+        // 最新のメッセージから逆順（desc）で取得し、フロント側で反転して表示する
+        const chatLogs = await prisma.chatLog.findMany({
+            where: { chatId: id },
+            orderBy: { createdAt: 'desc' },
+            take: take + 1, // 次ページの有無を判定するために1件多く取得
+            ...(cursor ? {
+                cursor: { id: cursor },
+                skip: 1, // カーソル自体はスキップする
+            } : {}),
         });
 
-        let formattedReflection = null;
-        if (latestReflection) {
-            const { response, ...base } = latestReflection;
-            formattedReflection = {
-                ...base,
-                response: typeof response === 'object' && response !== null ? { ...response } : response
-            };
+        // 追加データの有無を判定
+        const hasMore = chatLogs.length > take;
+        if (hasMore) {
+            chatLogs.pop(); // 判定用の余分な1件を除去
         }
 
-        // ペルソナの最新ステータスを取得
-        const fullStatus = await getLatestStatus(chat.personaId);
-        const status = flattenStatus(fullStatus);
+        // 次回取得用のカーソル（最も古いログのid）
+        const nextCursor = hasMore && chatLogs.length > 0
+            ? chatLogs[chatLogs.length - 1].id
+            : null;
 
+        // 時系列順（asc）に戻す
+        chatLogs.reverse();
 
-        return NextResponse.json({ ...chat, latestReflection: formattedReflection, status });
+        // 初回取得時（カーソルなし）のみ内省結果とステータスを返す
+        let latestReflection = null;
+        let status = null;
+
+        if (!cursor) {
+            const reflectionEvent = await prisma.reflectionEvent.findFirst({
+                where: { personaId: chat.personaId },
+                orderBy: { createdAt: 'desc' }
+            });
+
+            if (reflectionEvent) {
+                const { response, ...base } = reflectionEvent;
+                latestReflection = {
+                    ...base,
+                    response: typeof response === 'object' && response !== null ? { ...response } : response
+                };
+            }
+
+            const fullStatus = await getLatestStatus(chat.personaId);
+            status = flattenStatus(fullStatus);
+        }
+
+        return NextResponse.json({
+            ...chat,
+            chatLogs,
+            hasMore,
+            nextCursor,
+            latestReflection,
+            status,
+        });
     } catch (error: any) {
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/backend/src/app/api/personas/[id]/history/route.ts
+++ b/backend/src/app/api/personas/[id]/history/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+export const dynamic = 'force-dynamic';
+import { prisma } from "@/lib/prisma";
+
+/**
+ * ペルソナの不可逆データ（Lv2）の履歴を時系列で取得します。
+ * 人格ログページのグラフ表示に使用されます。
+ */
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id } = await params;
+
+        // ペルソナの存在確認
+        const persona = await prisma.persona.findUnique({
+            where: { id },
+            include: {
+                status: true
+            }
+        });
+
+        if (!persona) {
+            return NextResponse.json({ error: "Persona not found" }, { status: 404 });
+        }
+
+        if (!persona.status) {
+            return NextResponse.json({ error: "Persona status not found" }, { status: 404 });
+        }
+
+        // Lv2: 不可逆データの履歴を時系列順で取得
+        const irreversibleHistory = await prisma.quantityIrreversibleStatus.findMany({
+            where: { personaStatusId: persona.status.statusId },
+            orderBy: { recordedAt: 'asc' },
+        });
+
+        // Lv3-1: 可逆定量データの履歴
+        const reversibleHistory = await prisma.quantityReversibleStatus.findMany({
+            where: { personaStatusId: persona.status.statusId },
+            orderBy: { recordedAt: 'asc' },
+        });
+
+        // Lv3-2: 可逆半定量データ（感情等）の履歴
+        const semiquantityHistory = await prisma.semiquantityReversibleStatus.findMany({
+            where: { personaStatusId: persona.status.statusId },
+            orderBy: { recordedAt: 'asc' },
+        });
+
+        return NextResponse.json({
+            personaId: id,
+            personaName: persona.name,
+            irreversibleHistory,
+            reversibleHistory,
+            semiquantityHistory,
+        });
+    } catch (error: any) {
+        console.error("[API Persona History] Error:", error);
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+}

--- a/backend/src/app/api/personas/route.ts
+++ b/backend/src/app/api/personas/route.ts
@@ -85,19 +85,22 @@ export async function POST(req: NextRequest) {
                     personaStatusId: personaStatus.statusId,
                     version: 1,
                     height: vitalData?.height ? Number(vitalData.height) : 160.0,
-                    boneDensity: 100.0, // Default YAM%
-                    // others null
+                    boneDensity: vitalData?.boneDensity ? Number(vitalData.boneDensity) : 100.0,
+                    gripStrength: vitalData?.gripStrength ? Number(vitalData.gripStrength) : 30.0,
+                    eyesight: vitalData?.eyesight ? Number(vitalData.eyesight) : 1.0,
+                    hearingAbility: vitalData?.hearingAbility ? Number(vitalData.hearingAbility) : 20.0,
+                    voicePitch: vitalData?.voicePitch ? Number(vitalData.voicePitch) : 250.0,
                 }
             });
 
             // 6. Create Lv3-1: QuantityReversibleStatus (Initial JSON)
             const initialVitalJson = [
                 { label: "weight", value: vitalData?.weight ? Number(vitalData.weight) : 50.0, unit: "kg" },
-                { label: "bloodSugar", value: 90.0, unit: "mg/dL" },
-                { label: "bloodPressureSys", value: 110.0, unit: "mmHg" },
-                { label: "bloodPressureDia", value: 70.0, unit: "mmHg" },
-                { label: "sleepTime", value: 7.0, unit: "h" },
-                { label: "sleepQuality", value: 70.0, unit: null }
+                { label: "bloodSugar", value: vitalData?.bloodSugar ? Number(vitalData.bloodSugar) : 90.0, unit: "mg/dL" },
+                { label: "bloodPressureSys", value: vitalData?.bloodPressureSys ? Number(vitalData.bloodPressureSys) : 110.0, unit: "mmHg" },
+                { label: "bloodPressureDia", value: vitalData?.bloodPressureDia ? Number(vitalData.bloodPressureDia) : 70.0, unit: "mmHg" },
+                { label: "sleepTime", value: vitalData?.sleepTime ? Number(vitalData.sleepTime) : 7.0, unit: "h" },
+                { label: "sleepQuality", value: vitalData?.sleepQuality ? Number(vitalData.sleepQuality) : 70.0, unit: null }
             ];
 
             await tx.quantityReversibleStatus.create({

--- a/backend/src/app/api/personas/route.ts
+++ b/backend/src/app/api/personas/route.ts
@@ -85,7 +85,7 @@ export async function POST(req: NextRequest) {
                     personaStatusId: personaStatus.statusId,
                     version: 1,
                     height: vitalData?.height ? Number(vitalData.height) : 160.0,
-                    boneDensity: 1.0, // Default
+                    boneDensity: 100.0, // Default YAM%
                     // others null
                 }
             });

--- a/backend/src/app/api/reflect/route.ts
+++ b/backend/src/app/api/reflect/route.ts
@@ -213,7 +213,11 @@ ${logSummary}
         const irreversibleData = {
             personaStatusId: fullStatus.statusId,
             height: newHeight,
-            boneDensity: fullStatus.quantityIrreversible?.boneDensity ?? 1.0,
+            boneDensity: fullStatus.quantityIrreversible?.boneDensity ?? 100.0,
+            gripStrength: fullStatus.quantityIrreversible?.gripStrength,
+            voicePitch: fullStatus.quantityIrreversible?.voicePitch,
+            eyesight: fullStatus.quantityIrreversible?.eyesight,
+            hearingAbility: fullStatus.quantityIrreversible?.hearingAbility,
             version: (fullStatus.quantityIrreversible?.version || 0) + 1,
         };
 

--- a/backend/src/lib/persona.ts
+++ b/backend/src/lib/persona.ts
@@ -118,6 +118,10 @@ export function flattenStatus(fullStatus: any) {
         // Lv2: QuantityIrreversible
         height: fullStatus.quantityIrreversible?.height,
         boneDensity: fullStatus.quantityIrreversible?.boneDensity,
+        gripStrength: fullStatus.quantityIrreversible?.gripStrength,
+        voicePitch: fullStatus.quantityIrreversible?.voicePitch,
+        eyesight: fullStatus.quantityIrreversible?.eyesight,
+        hearingAbility: fullStatus.quantityIrreversible?.hearingAbility,
 
         // Lv3-1: QuantityReversible (JSON parsing)
         weight: getVal(reversibleVal, "weight"),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hot-toast": "^2.6.0",
+        "recharts": "^3.7.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -988,6 +989,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -1320,6 +1357,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -1622,6 +1671,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1649,7 +1761,7 @@
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1664,6 +1776,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.1",
@@ -2271,6 +2389,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2288,6 +2527,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2392,6 +2637,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -2640,6 +2895,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3006,6 +3267,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3031,6 +3302,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -3760,6 +4040,36 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3769,6 +4079,57 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3927,6 +4288,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4059,6 +4426,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hot-toast": "^2.6.0",
+    "recharts": "^3.7.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import axios from 'axios';
 import { Send, Menu, ChevronLeft, Database, Sun, Moon, MessageSquare, BarChart3 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -141,6 +141,11 @@ function App() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  /** ページネーション用ステート */
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
   /** メインエリアのタブ状態: 'chat' | 'persona-log' */
   const [activeTab, setActiveTab] = useState<'chat' | 'persona-log'>('chat');
 
@@ -259,6 +264,8 @@ function App() {
       if (!currentChatId) {
         console.log('[App] No currentChatId, clearing messages.');
         setMessages([]);
+        setNextCursor(null);
+        setHasMore(false);
         return;
       }
       try {
@@ -270,6 +277,8 @@ function App() {
           createdAt: log.createdAt
         }));
         setMessages(history);
+        setNextCursor(res.data.nextCursor || null);
+        setHasMore(res.data.hasMore || false);
 
         // 内省結果があればセット
         if (res.data.latestReflection) {
@@ -291,10 +300,80 @@ function App() {
     fetchChatSession();
   }, [currentChatId]);
 
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  /**
+   * 古いメッセージを追加取得する（上方向スクロール時に呼ばれる）
+   * スクロール位置を古いメッセージ挿入後も維持するため、
+   * 挿入前のscrollHeightを記録し、挿入後に差分だけスクロール位置を補正する
+   */
+  const fetchOlderMessages = useCallback(async () => {
+    if (!currentChatId || !nextCursor || isLoadingMore || !hasMore) return;
+    setIsLoadingMore(true);
+    try {
+      const scrollEl = scrollRef.current;
+      const prevScrollHeight = scrollEl?.scrollHeight || 0;
+
+      const res = await axios.get(`${API_URL}/api/chats/${currentChatId}`, {
+        params: { cursor: nextCursor }
+      });
+      const olderMessages: Message[] = res.data.chatLogs.map((log: any) => ({
+        role: log.role as 'user' | 'assistant',
+        content: log.content,
+        createdAt: log.createdAt
+      }));
+
+      if (olderMessages.length > 0) {
+        setMessages(prev => [...olderMessages, ...prev]);
+        setNextCursor(res.data.nextCursor || null);
+        setHasMore(res.data.hasMore || false);
+
+        // スクロール位置を維持する（次のレンダリング後に補正）
+        requestAnimationFrame(() => {
+          if (scrollEl) {
+            const newScrollHeight = scrollEl.scrollHeight;
+            scrollEl.scrollTop = newScrollHeight - prevScrollHeight;
+          }
+        });
+      } else {
+        setHasMore(false);
+      }
+    } catch (error) {
+      console.error('[App] Failed to fetch older messages:', error);
+    } finally {
+      setIsLoadingMore(false);
     }
+  }, [currentChatId, nextCursor, isLoadingMore, hasMore]);
+
+  /**
+   * 上方向スクロール検知：スクロール位置が上部に近づいたら古いメッセージを取得
+   */
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+
+    const handleScroll = () => {
+      // スクロール位置が上部100px以内に来たら追加取得
+      if (scrollEl.scrollTop < 100 && hasMore && !isLoadingMore) {
+        fetchOlderMessages();
+      }
+    };
+
+    scrollEl.addEventListener('scroll', handleScroll);
+    return () => scrollEl.removeEventListener('scroll', handleScroll);
+  }, [hasMore, isLoadingMore, fetchOlderMessages]);
+
+  /** 新しいメッセージが追加された場合のみ最下部にスクロール */
+  const prevMessageCountRef = useRef(0);
+  useEffect(() => {
+    // メッセージ数が増えた場合（新規送信）のみ自動スクロール
+    // 古いメッセージの読み込み時はスクロールしない（fetchOlderMessages内で位置を維持済み）
+    if (messages.length > prevMessageCountRef.current && scrollRef.current) {
+      const isOlderMessageLoad = prevMessageCountRef.current === 0 ||
+        (messages.length - prevMessageCountRef.current <= 2);
+      if (isOlderMessageLoad || prevMessageCountRef.current === 0) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      }
+    }
+    prevMessageCountRef.current = messages.length;
   }, [messages]);
 
   const handleSend = async () => {
@@ -497,6 +576,25 @@ function App() {
                 className="flex-1 overflow-y-auto px-4 py-6 scroll-smooth scrollbar-hide"
               >
                 <div className="w-full max-w-[740px] mx-auto space-y-6">
+                  {/* 過去のメッセージ読み込みインジケーター */}
+                  {isLoadingMore && (
+                    <div className="flex justify-center py-3">
+                      <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500 bg-slate-100 dark:bg-slate-800 px-4 py-2 rounded-full">
+                        <span className="w-3 h-3 border-2 border-slate-300 dark:border-slate-600 border-t-blue-500 rounded-full animate-spin" />
+                        過去のメッセージを読み込み中...
+                      </div>
+                    </div>
+                  )}
+                  {hasMore && !isLoadingMore && (
+                    <div className="flex justify-center py-2">
+                      <button
+                        onClick={fetchOlderMessages}
+                        className="text-xs text-slate-400 dark:text-slate-500 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+                      >
+                        ↑ 過去のメッセージを表示
+                      </button>
+                    </div>
+                  )}
                   <AnimatePresence initial={false}>
                     {messages.length === 0 && (
                       <motion.div

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,10 @@ interface PersonaStatus {
   height: number;
   weight: number;
   boneDensity?: number;
+  gripStrength?: number;
+  voicePitch?: number;
+  eyesight?: number;
+  hearingAbility?: number;
   bloodSugar?: number;
   bloodPressureSys?: number;
   bloodPressureDia?: number;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,19 @@
 import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
-import { Send, Menu, ChevronLeft, Database, Sun, Moon, ChevronDown } from 'lucide-react';
+import { Send, Menu, ChevronLeft, Database, Sun, Moon, ChevronDown, MessageSquare, BarChart3 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import toast, { Toaster } from 'react-hot-toast';
 import { BotSidebar } from './components/BotSidebar';
 import { ChatHistory } from './components/ChatHistory';
 import { PersonaCreationModal } from './components/PersonaCreationModal';
+import { PersonaLogTab } from './components/PersonaLogTab';
 import { handleApiError } from './utils/errorHandler';
 
 interface Message {
   role: 'user' | 'assistant';
   content: string;
+  /** メッセージの送信日時 */
+  createdAt?: string;
 }
 
 interface Persona {
@@ -131,6 +134,10 @@ function App() {
   });
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  /** メインエリアのタブ状態: 'chat' | 'persona-log' */
+  const [activeTab, setActiveTab] = useState<'chat' | 'persona-log'>('chat');
 
   // Load state from localStorage
   const [currentPersonaId, setCurrentPersonaId] = useState<string | null>(() => localStorage.getItem('currentPersonaId'));
@@ -252,7 +259,8 @@ function App() {
         const res = await axios.get(`${API_URL}/api/chats/${currentChatId}`);
         const history = res.data.chatLogs.map((log: any) => ({
           role: log.role as 'user' | 'assistant',
-          content: log.content
+          content: log.content,
+          createdAt: log.createdAt
         }));
         setMessages(history);
 
@@ -285,10 +293,15 @@ function App() {
   const handleSend = async () => {
     if (!input.trim() || isLoading) return;
 
-    const userMsg: Message = { role: 'user', content: input };
+    const userMsg: Message = { role: 'user', content: input, createdAt: new Date().toISOString() };
     setMessages(prev => [...prev, userMsg]);
     setInput('');
     setIsLoading(true);
+
+    // テキストエリアの高さをリセット
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
 
     try {
       const llmConfig = {
@@ -308,7 +321,7 @@ function App() {
       if (!currentChatId && res.data.chatId) {
         setCurrentChatId(res.data.chatId);
       }
-      const aiMsg: Message = { role: 'assistant', content: res.data.response };
+      const aiMsg: Message = { role: 'assistant', content: res.data.response, createdAt: new Date().toISOString() };
       setMessages(prev => [...prev, aiMsg]);
       if (res.data.status) setStatus(res.data.status);
       if (res.data.debug) setLastDebugInfo(res.data.debug);
@@ -352,7 +365,7 @@ function App() {
       setLastReflection(res.data.reflection);
 
       const followUpMessage = "内省が終わったようですね。今の気分はどうですか？";
-      setMessages(prev => [...prev, { role: 'user', content: followUpMessage }]);
+      setMessages(prev => [...prev, { role: 'user', content: followUpMessage, createdAt: new Date().toISOString() }]);
 
       const resChat = await axios.post(`${API_URL}/api/chat`, {
         message: followUpMessage,
@@ -360,7 +373,7 @@ function App() {
         chatId: currentChatId,
         personaId: currentPersonaId
       });
-      setMessages(prev => [...prev, { role: 'assistant', content: resChat.data.response }]);
+      setMessages(prev => [...prev, { role: 'assistant', content: resChat.data.response, createdAt: new Date().toISOString() }]);
       if (resChat.data.status) setStatus(resChat.data.status);
       setRefreshTrigger(prev => prev + 1);
     } catch (error) {
@@ -450,82 +463,143 @@ function App() {
         {/* Main Chat Area */}
         <main className="flex-1 flex flex-col relative bg-slate-50 dark:bg-slate-950 min-w-0">
 
-          {/* Messages */}
-          <div
-            ref={scrollRef}
-            className="flex-1 overflow-y-auto px-4 py-6 scroll-smooth scrollbar-hide"
-          >
-            <div className="w-full max-w-[740px] mx-auto space-y-6">
-              <AnimatePresence initial={false}>
-                {messages.length === 0 && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    className="h-full flex flex-col items-center justify-center text-slate-400 dark:text-slate-600 space-y-4 py-20"
-                  >
-                    <Database size={48} className="opacity-10" />
-                    <p className="text-lg text-slate-500">対話を開始して、意識を呼び覚ましてください</p>
-                  </motion.div>
-                )}
-                {messages.map((m, i) => (
-                  <motion.div
-                    key={i}
-                    initial={{ opacity: 0, x: 0, y: 10 }}
-                    animate={{ opacity: 1, x: 0, y: 0 }}
-                    className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
-                  >
-                    <div className={`max-w-[85%] p-4 rounded-2xl shadow-sm transition-colors duration-300 ${m.role === 'user'
-                      ? 'bg-blue-600 text-white rounded-br-none'
-                      : 'bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 dark:text-slate-100 rounded-bl-none'
-                      }`}>
-                      <p className="leading-relaxed whitespace-pre-wrap">{m.content}</p>
-                    </div>
-                  </motion.div>
-                ))}
-              </AnimatePresence>
-              {isLoading && (
-                <div className="flex justify-start">
-                  <div className="bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 p-4 rounded-2xl rounded-bl-none flex gap-2">
-                    <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce" />
-                    <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0.2s]" />
-                    <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0.4s]" />
-                  </div>
-                </div>
-              )}
-            </div>
+          {/* タブ切り替え (#38: メインディスプレイのタブ分割) */}
+          <div className="flex items-center border-b border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm px-4 shrink-0">
+            <button
+              onClick={() => setActiveTab('chat')}
+              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-all duration-200 ${
+                activeTab === 'chat'
+                  ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 hover:border-slate-300 dark:hover:border-slate-600'
+              }`}
+            >
+              <MessageSquare className="w-4 h-4" />
+              Chat
+            </button>
+            <button
+              onClick={() => setActiveTab('persona-log')}
+              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-all duration-200 ${
+                activeTab === 'persona-log'
+                  ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                  : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 hover:border-slate-300 dark:hover:border-slate-600'
+              }`}
+            >
+              <BarChart3 className="w-4 h-4" />
+              人格ログ
+            </button>
           </div>
 
-          {/* Input Area */}
-          <div className="p-4 pt-0 z-10">
-            <div className="w-full max-w-[740px] mx-auto">
-              <div className="flex gap-3 p-2 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-xl focus-within:ring-2 focus-within:ring-blue-500/20 transition-all">
-                <input
-                  type="text"
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleSend()}
-                  placeholder="何でも話しかけてください..."
-                  className="flex-1 bg-transparent border-none outline-none px-4 py-2 text-slate-900 dark:text-slate-100 placeholder-slate-400"
-                />
-                <button
-                  onClick={handleSend}
-                  disabled={isLoading}
-                  className="p-3 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 rounded-xl transition-colors shadow-lg shadow-blue-500/20 text-white"
-                >
-                  <Send size={20} />
-                </button>
+          {/* タブコンテンツ */}
+          {activeTab === 'chat' ? (
+            <>
+              {/* Messages (#14: 時刻表示付き) */}
+              <div
+                ref={scrollRef}
+                className="flex-1 overflow-y-auto px-4 py-6 scroll-smooth scrollbar-hide"
+              >
+                <div className="w-full max-w-[740px] mx-auto space-y-6">
+                  <AnimatePresence initial={false}>
+                    {messages.length === 0 && (
+                      <motion.div
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        className="h-full flex flex-col items-center justify-center text-slate-400 dark:text-slate-600 space-y-4 py-20"
+                      >
+                        <Database size={48} className="opacity-10" />
+                        <p className="text-lg text-slate-500">対話を開始して、意識を呼び覚ましてください</p>
+                      </motion.div>
+                    )}
+                    {messages.map((m, i) => (
+                      <motion.div
+                        key={i}
+                        initial={{ opacity: 0, x: 0, y: 10 }}
+                        animate={{ opacity: 1, x: 0, y: 0 }}
+                        className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                      >
+                        <div className="flex flex-col gap-1 max-w-[85%]">
+                          <div className={`p-4 rounded-2xl shadow-sm transition-colors duration-300 ${m.role === 'user'
+                            ? 'bg-blue-600 text-white rounded-br-none'
+                            : 'bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 dark:text-slate-100 rounded-bl-none'
+                            }`}>
+                            <p className="leading-relaxed whitespace-pre-wrap">{m.content}</p>
+                          </div>
+                          {/* 時刻表示 (#14) */}
+                          {m.createdAt && (
+                            <span className={`text-[10px] text-slate-400 dark:text-slate-500 px-1 ${
+                              m.role === 'user' ? 'text-right' : 'text-left'
+                            }`}>
+                              {new Date(m.createdAt).toLocaleTimeString('ja-JP', {
+                                hour: '2-digit',
+                                minute: '2-digit',
+                              })}
+                            </span>
+                          )}
+                        </div>
+                      </motion.div>
+                    ))}
+                  </AnimatePresence>
+                  {isLoading && (
+                    <div className="flex justify-start">
+                      <div className="bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 p-4 rounded-2xl rounded-bl-none flex gap-2">
+                        <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce" />
+                        <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0.2s]" />
+                        <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0.4s]" />
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
-              <div className="text-center mt-4 mb-2">
-                <button
-                  onClick={handleReflect}
-                  disabled={isLoading}
-                  className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 text-xs font-semibold tracking-wide cursor-pointer disabled:cursor-not-allowed"
-                >
-                  内省を実行する
-                </button>
+
+              {/* Input Area (#24: Shift+Enterで改行対応) */}
+              <div className="p-4 pt-0 z-10">
+                <div className="w-full max-w-[740px] mx-auto">
+                  <div className="flex gap-3 p-2 bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-xl focus-within:ring-2 focus-within:ring-blue-500/20 transition-all items-end">
+                    <textarea
+                      ref={textareaRef}
+                      value={input}
+                      onChange={(e) => {
+                        setInput(e.target.value);
+                        // テキストエリアの高さを自動調整
+                        const target = e.target;
+                        target.style.height = 'auto';
+                        target.style.height = Math.min(target.scrollHeight, 160) + 'px';
+                      }}
+                      onKeyDown={(e) => {
+                        // Enterのみで送信、Shift+Enterで改行
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          handleSend();
+                        }
+                      }}
+                      placeholder="何でも話しかけてください... (Shift+Enterで改行)"
+                      rows={1}
+                      className="flex-1 bg-transparent border-none outline-none px-4 py-2 text-slate-900 dark:text-slate-100 placeholder-slate-400 resize-none overflow-y-auto scrollbar-hide"
+                      style={{ maxHeight: '160px' }}
+                    />
+                    <button
+                      onClick={handleSend}
+                      disabled={isLoading}
+                      className="p-3 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 rounded-xl transition-colors shadow-lg shadow-blue-500/20 text-white shrink-0"
+                    >
+                      <Send size={20} />
+                    </button>
+                  </div>
+                  <div className="text-center mt-4 mb-2">
+                    <button
+                      onClick={handleReflect}
+                      disabled={isLoading}
+                      className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 text-xs font-semibold tracking-wide cursor-pointer disabled:cursor-not-allowed"
+                    >
+                      内省を実行する
+                    </button>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            </>
+          ) : (
+            /* 人格ログタブ (#38) */
+            <PersonaLogTab currentPersonaId={currentPersonaId} />
+          )}
         </main>
 
         {/* Chat History Sidebar (Right) */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
-import { Send, Menu, ChevronLeft, Database, Sun, Moon, ChevronDown, MessageSquare, BarChart3 } from 'lucide-react';
+import { Send, Menu, ChevronLeft, Database, Sun, Moon, MessageSquare, BarChart3 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import toast, { Toaster } from 'react-hot-toast';
 import { BotSidebar } from './components/BotSidebar';
 import { ChatHistory } from './components/ChatHistory';
 import { PersonaCreationModal } from './components/PersonaCreationModal';
+import { PersonaSelector } from './components/PersonaSelector';
 import { PersonaLogTab } from './components/PersonaLogTab';
 import { handleApiError } from './utils/errorHandler';
 
@@ -418,29 +419,16 @@ function App() {
           <h1 className="text-lg font-bold text-slate-800 dark:text-slate-100 ml-2">Reflecta Chat</h1>
           
           {/* Persona Selector */}
-          <div className="relative ml-4">
-            <select
-                value={currentPersonaId || ""}
-                onChange={(e) => {
-                    const val = e.target.value;
-                    if (val === "NEW") {
-                        setIsPersonaModalOpen(true);
-                    } else {
-                        setCurrentPersonaId(val);
-                        setCurrentChatId(null);
-                        setMessages([]); // Clear messages on persona switch
-                    }
-                }}
-                className="appearance-none pl-3 pr-8 py-1 bg-blue-50 dark:bg-slate-800 border border-blue-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 rounded-lg text-sm font-medium focus:ring-2 focus:ring-blue-500 outline-none cursor-pointer hover:bg-blue-100 dark:hover:bg-slate-700 transition-colors"
-            >
-                {personas.map(p => (
-                    <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-                <option disabled>──────────</option>
-                <option value="NEW">＋ 新規ペルソナ作成</option>
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 pointer-events-none" />
-          </div>
+          <PersonaSelector
+            personas={personas}
+            currentPersonaId={currentPersonaId}
+            onSelect={(personaId) => {
+              setCurrentPersonaId(personaId);
+              setCurrentChatId(null);
+              setMessages([]); // ペルソナ切り替え時にメッセージをクリア
+            }}
+            onCreateNew={() => setIsPersonaModalOpen(true)}
+          />
         </div>
 
         <div className="flex items-center gap-2">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import axios from 'axios';
-import { Send, Menu, ChevronLeft, Database, Sun, Moon, MessageSquare, BarChart3 } from 'lucide-react';
+import { Send, Menu, ChevronLeft, Database, Sun, Moon, MessageSquare, BarChart3, ArrowDown } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import toast, { Toaster } from 'react-hot-toast';
 import { BotSidebar } from './components/BotSidebar';
@@ -91,6 +91,26 @@ export interface ReflectionResult {
 
 const API_URL = import.meta.env.VITE_API_URL || '';
 
+/**
+ * 日付ラベルを生成するヘルパー関数
+ * 今日・昨日は相対表示、それ以外は「YYYY年M月D日」形式
+ */
+const getDateLabel = (dateStr: string): string => {
+  const date = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  if (date.toDateString() === today.toDateString()) return '今日';
+  if (date.toDateString() === yesterday.toDateString()) return '昨日';
+
+  return date.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
 function App() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
@@ -145,6 +165,8 @@ function App() {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  /** スクロール位置が最下部付近にいるか（フローティングボタン表示判定用） */
+  const [isNearBottom, setIsNearBottom] = useState(true);
 
   /** メインエリアのタブ状態: 'chat' | 'persona-log' */
   const [activeTab, setActiveTab] = useState<'chat' | 'persona-log'>('chat');
@@ -344,7 +366,21 @@ function App() {
   }, [currentChatId, nextCursor, isLoadingMore, hasMore]);
 
   /**
-   * 上方向スクロール検知：スクロール位置が上部に近づいたら古いメッセージを取得
+   * 最下部へスムーズスクロールする
+   */
+  const scrollToBottom = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({
+        top: scrollRef.current.scrollHeight,
+        behavior: 'smooth'
+      });
+    }
+  }, []);
+
+  /**
+   * スクロールイベントハンドラ
+   * - 上方向スクロール検知：古いメッセージを取得
+   * - 最下部判定：フローティングボタン表示用
    */
   useEffect(() => {
     const scrollEl = scrollRef.current;
@@ -355,6 +391,9 @@ function App() {
       if (scrollEl.scrollTop < 100 && hasMore && !isLoadingMore) {
         fetchOlderMessages();
       }
+      // 最下部付近にいるか判定（150px以内なら最下部とみなす）
+      const distanceFromBottom = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
+      setIsNearBottom(distanceFromBottom < 150);
     };
 
     scrollEl.addEventListener('scroll', handleScroll);
@@ -606,34 +645,60 @@ function App() {
                         <p className="text-lg text-slate-500">対話を開始して、意識を呼び覚ましてください</p>
                       </motion.div>
                     )}
-                    {messages.map((m, i) => (
-                      <motion.div
-                        key={i}
-                        initial={{ opacity: 0, x: 0, y: 10 }}
-                        animate={{ opacity: 1, x: 0, y: 0 }}
-                        className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
-                      >
-                        <div className="flex flex-col gap-1 max-w-[85%]">
-                          <div className={`p-4 rounded-2xl shadow-sm transition-colors duration-300 ${m.role === 'user'
-                            ? 'bg-blue-600 text-white rounded-br-none'
-                            : 'bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 dark:text-slate-100 rounded-bl-none'
-                            }`}>
-                            <p className="leading-relaxed whitespace-pre-wrap">{m.content}</p>
-                          </div>
-                          {/* 時刻表示 (#14) */}
-                          {m.createdAt && (
-                            <span className={`text-[10px] text-slate-400 dark:text-slate-500 px-1 ${
-                              m.role === 'user' ? 'text-right' : 'text-left'
-                            }`}>
-                              {new Date(m.createdAt).toLocaleTimeString('ja-JP', {
-                                hour: '2-digit',
-                                minute: '2-digit',
-                              })}
+                    {messages.flatMap((m, i) => {
+                      const elements: React.ReactNode[] = [];
+
+                      // 日付が変わったタイミングで日付ラベルを挿入
+                      const showDateLabel = m.createdAt && (
+                        i === 0 ||
+                        !messages[i - 1].createdAt ||
+                        new Date(m.createdAt).toDateString() !== new Date(messages[i - 1].createdAt!).toDateString()
+                      );
+
+                      if (showDateLabel) {
+                        elements.push(
+                          <div
+                            key={`date-${i}`}
+                            className="sticky top-0 z-10 flex justify-center py-2"
+                          >
+                            <span className="text-[11px] font-medium text-slate-500 dark:text-slate-400 bg-slate-100/90 dark:bg-slate-800/90 backdrop-blur-sm px-4 py-1.5 rounded-full shadow-sm border border-slate-200/50 dark:border-slate-700/50">
+                              {getDateLabel(m.createdAt!)}
                             </span>
-                          )}
-                        </div>
-                      </motion.div>
-                    ))}
+                          </div>
+                        );
+                      }
+
+                      elements.push(
+                        <motion.div
+                          key={`msg-${i}`}
+                          initial={{ opacity: 0, x: 0, y: 10 }}
+                          animate={{ opacity: 1, x: 0, y: 0 }}
+                          className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                        >
+                          <div className="flex flex-col gap-1 max-w-[85%]">
+                            <div className={`p-4 rounded-2xl shadow-sm transition-colors duration-300 ${m.role === 'user'
+                              ? 'bg-blue-600 text-white rounded-br-none'
+                              : 'bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 dark:text-slate-100 rounded-bl-none'
+                              }`}>
+                              <p className="leading-relaxed whitespace-pre-wrap">{m.content}</p>
+                            </div>
+                            {/* 時刻表示 (#14) */}
+                            {m.createdAt && (
+                              <span className={`text-[10px] text-slate-400 dark:text-slate-500 px-1 ${
+                                m.role === 'user' ? 'text-right' : 'text-left'
+                              }`}>
+                                {new Date(m.createdAt).toLocaleTimeString('ja-JP', {
+                                  hour: '2-digit',
+                                  minute: '2-digit',
+                                })}
+                              </span>
+                            )}
+                          </div>
+                        </motion.div>
+                      );
+
+                      return elements;
+                    })}
                   </AnimatePresence>
                   {isLoading && (
                     <div className="flex justify-start">
@@ -646,6 +711,23 @@ function App() {
                   )}
                 </div>
               </div>
+
+              {/* フローティングボタン: 最新メッセージへ */}
+              <AnimatePresence>
+                {!isNearBottom && messages.length > 0 && (
+                  <motion.button
+                    initial={{ opacity: 0, y: 20, scale: 0.9 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: 20, scale: 0.9 }}
+                    transition={{ duration: 0.2 }}
+                    onClick={scrollToBottom}
+                    className="absolute bottom-24 right-8 z-20 flex items-center gap-1.5 px-4 py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium rounded-full shadow-lg hover:shadow-xl transition-all cursor-pointer"
+                  >
+                    <ArrowDown className="w-3.5 h-3.5" />
+                    最新のメッセージへ
+                  </motion.button>
+                )}
+              </AnimatePresence>
 
               {/* Input Area (#24: Shift+Enterで改行対応) */}
               <div className="p-4 pt-0 z-10">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -205,19 +205,21 @@ function App() {
     fetchPersonas();
   }, []);
 
+  // ペルソナのステータスを取得する関数
+  const fetchPersonaStatus = async () => {
+      if (!currentPersonaId) return;
+      try {
+          const res = await axios.get(`${API_URL}/api/personas/${currentPersonaId}`);
+          if (res.data) {
+              setStatus(res.data);
+          }
+      } catch (error) {
+          console.error('Failed to fetch persona status:', error);
+      }
+  };
+
   // ペルソナ変更時にステータスを取得
   useEffect(() => {
-    const fetchPersonaStatus = async () => {
-        if (!currentPersonaId) return;
-        try {
-            const res = await axios.get(`${API_URL}/api/personas/${currentPersonaId}`);
-            if (res.data) {
-                setStatus(res.data);
-            }
-        } catch (error) {
-            console.error('Failed to fetch persona status:', error);
-        }
-    };
     fetchPersonaStatus();
   }, [currentPersonaId]);
 
@@ -462,6 +464,7 @@ function App() {
           isOpen={isLeftOpen}
           status={status}
           lastDebugInfo={lastDebugInfo}
+          onStatusRefresh={fetchPersonaStatus}
         />
 
         {/* Main Chat Area */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -362,7 +362,11 @@ function App() {
           secondary: '#10B981',
         },
       });
-      setLastReflection(res.data.reflection);
+      setLastReflection({
+        id: 'temp-id',
+        createdAt: new Date().toISOString(),
+        response: res.data.reflection
+      });
 
       const followUpMessage = "内省が終わったようですね。今の気分はどうですか？";
       setMessages(prev => [...prev, { role: 'user', content: followUpMessage, createdAt: new Date().toISOString() }]);
@@ -598,7 +602,10 @@ function App() {
             </>
           ) : (
             /* 人格ログタブ (#38) */
-            <PersonaLogTab currentPersonaId={currentPersonaId} />
+            <PersonaLogTab 
+              key={`${currentPersonaId}-${refreshTrigger}`} 
+              currentPersonaId={currentPersonaId} 
+            />
           )}
         </main>
 

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -265,7 +265,7 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                             {/* Personality Chart */}
                             <div>
                                 <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <Terminal className="w-3 h-3" /> 性格(Lv2)
+                                    <Terminal className="w-3 h-3" /> 性格(Lv1-2)
                                 </h3>
                                 <div className="space-y-3">
                                     {personalityStats.map((stat, i) => (

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -68,22 +68,22 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
         { label: 'Age', value: status.birthDate ? `${new Date().getFullYear() - new Date(status.birthDate).getFullYear()}歳` : 'Unknown' },
         { label: 'Gender', value: status.gender || 'Unknown' },
         { label: 'Type', value: status.chronotype || 'Unknown' },
-        { label: 'IQ', value: status.intelligence?.toString() || '?' },
+        { label: 'Intelligence', value: status.intelligence?.toString() || '?' },
     ];
 
     const personalityStats = [
-        { label: 'Ethics', value: status.ethics },
-        { label: 'Passion', value: status.passion },
-        { label: 'Curiosity', value: status.curiosity },
-        { label: 'Aggression', value: status.aggressiveness },
-        { label: 'Extroversion', value: status.extroversion },
+        { label: '倫理観', value: status.ethics },
+        { label: '情熱', value: status.passion },
+        { label: '好奇心', value: status.curiosity },
+        { label: '攻撃性', value: status.aggressiveness },
+        { label: '外向性', value: status.extroversion },
     ];
 
     const bodyStats = [
-        { label: 'Height', value: `${status.height}cm` },
-        { label: 'Weight', value: `${status.weight}kg` },
-        { label: 'Sleep', value: `${status.sleepTime ?? '?'}h` },
-        { label: 'BP', value: `${status.bloodPressureSys ?? '?'}/${status.bloodPressureDia ?? '?'}` },
+        { label: '身長', value: `${status.height}cm` },
+        { label: '体重', value: `${status.weight}kg` },
+        { label: '睡眠時間', value: `${status.sleepTime ?? '?'}h` },
+        { label: '血圧', value: `${status.bloodPressureSys ?? '?'}/${status.bloodPressureDia ?? '?'}` },
     ];
 
     const handleStartEditName = () => {
@@ -172,7 +172,6 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                     {status.name || 'Reflecta'}
                 </h2>
             )}
-            <p className="text-xs text-slate-500 dark:text-slate-400 font-mono mt-1">Self-Evolving AI</p>
         </div>
     );
 
@@ -249,7 +248,7 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                             {/* Body Stats */}
                             <div>
                                 <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <Activity className="w-3 h-3" /> Body
+                                    <Activity className="w-3 h-3" /> 身体特性
                                 </h3>
                                 <div className="grid grid-cols-2 gap-2">
                                     {bodyStats.map((stat, i) => (
@@ -264,7 +263,7 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                             {/* Personality Chart */}
                             <div>
                                 <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <Terminal className="w-3 h-3" /> Personality (Lv2)
+                                    <Terminal className="w-3 h-3" /> 性格
                                 </h3>
                                 <div className="space-y-3">
                                     {personalityStats.map((stat, i) => (

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -218,51 +218,6 @@ export function BotSidebar({ isOpen, status, lastDebugInfo }: BotSidebarProps) {
                                 </span>
                             </div>
 
-                            {/* System Prompt Section */}
-                            <div>
-                                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2 px-1 flex justify-between items-center">
-                                    System Prompt
-                                    {!isEditingSystemPrompt && (
-                                        <button 
-                                            onClick={() => {
-                                                setEditingSystemPrompt(status.systemPrompt || '');
-                                                setIsEditingSystemPrompt(true);
-                                            }}
-                                            className="text-blue-500 hover:text-blue-600 text-[10px] font-normal"
-                                        >
-                                            Edit
-                                        </button>
-                                    )}
-                                </h3>
-                                {isEditingSystemPrompt ? (
-                                    <div className="space-y-2">
-                                        <textarea
-                                            value={editingSystemPromptText}
-                                            onChange={(e) => setEditingSystemPrompt(e.target.value)}
-                                            className="w-full p-2 text-xs bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded focus:ring-2 focus:ring-blue-500 outline-none min-h-[100px]"
-                                            placeholder="追加のシステムプロンプトを入力..."
-                                        />
-                                        <div className="flex justify-end gap-2">
-                                            <button 
-                                                onClick={() => setIsEditingSystemPrompt(false)}
-                                                className="text-xs text-slate-500 hover:text-slate-700"
-                                            >
-                                                Cancel
-                                            </button>
-                                            <button 
-                                                onClick={handleSaveSystemPrompt}
-                                                className="text-xs bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded"
-                                            >
-                                                Save
-                                            </button>
-                                        </div>
-                                    </div>
-                                ) : (
-                                    <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg p-3 text-xs text-slate-600 dark:text-slate-400 border border-slate-100 dark:border-slate-800 whitespace-pre-wrap">
-                                        {status.systemPrompt || <span className="text-slate-400 italic">No additional system prompt set.</span>}
-                                    </div>
-                                )}
-                            </div>
 
                             {/* Condition Group */}
                             <div>
@@ -334,6 +289,54 @@ export function BotSidebar({ isOpen, status, lastDebugInfo }: BotSidebarProps) {
                         </div>
                     ) : (
                         <div className="space-y-6">
+                            {/* User System Prompt 編集セクション（STATUSから移動） */}
+                            <div>
+                                <h3 className="text-xs font-bold text-purple-600 dark:text-purple-400 uppercase tracking-wider mb-2 px-1 flex justify-between items-center">
+                                    <span className="flex items-center gap-2">
+                                        <FileText className="w-3 h-3" /> Custom System Prompt
+                                    </span>
+                                    {!isEditingSystemPrompt && (
+                                        <button 
+                                            onClick={() => {
+                                                setEditingSystemPrompt(status.systemPrompt || '');
+                                                setIsEditingSystemPrompt(true);
+                                            }}
+                                            className="text-purple-500 hover:text-purple-600 text-[10px] font-normal"
+                                        >
+                                            Edit
+                                        </button>
+                                    )}
+                                </h3>
+                                {isEditingSystemPrompt ? (
+                                    <div className="space-y-2">
+                                        <textarea
+                                            value={editingSystemPromptText}
+                                            onChange={(e) => setEditingSystemPrompt(e.target.value)}
+                                            className="w-full p-2 text-xs bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded focus:ring-2 focus:ring-purple-500 outline-none min-h-[100px]"
+                                            placeholder="追加のシステムプロンプトを入力..."
+                                        />
+                                        <div className="flex justify-end gap-2">
+                                            <button 
+                                                onClick={() => setIsEditingSystemPrompt(false)}
+                                                className="text-xs text-slate-500 hover:text-slate-700"
+                                            >
+                                                Cancel
+                                            </button>
+                                            <button 
+                                                onClick={handleSaveSystemPrompt}
+                                                className="text-xs bg-purple-500 hover:bg-purple-600 text-white px-3 py-1 rounded"
+                                            >
+                                                Save
+                                            </button>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg p-3 text-xs text-slate-600 dark:text-slate-400 border border-slate-100 dark:border-slate-800 whitespace-pre-wrap">
+                                        {status.systemPrompt || <span className="text-slate-400 italic">No additional system prompt set.</span>}
+                                    </div>
+                                )}
+                            </div>
+
                             {/* Debug Info View */}
                             {!lastDebugInfo ? (
                                 <div className="text-center py-10 text-slate-400">

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -38,9 +38,6 @@ export interface DebugInfo {
     contextMemories: { content: string | null; distance: number | null }[];
 }
 
-
-
-
 type BotSidebarProps = {
     isOpen: boolean;
     status: PersonaStatus;

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -57,18 +57,18 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
 
     // Stats Categorization
     const conditionStats = [
-        { icon: Heart, label: 'Health', value: `${status.health}%`, color: 'text-rose-500' },
-        { icon: Sparkles, label: 'Mood', value: `${status.mood}%`, color: 'text-amber-500' },
-        { icon: Database, label: 'Trust', value: `${status.trust}%`, color: 'text-emerald-500' },
-        { icon: User, label: 'Friendliness', value: `${status.friendliness || 0}%`, color: 'text-pink-500' },
+        { icon: Heart, label: '健康', value: `${status.health}%`, color: 'text-rose-500' },
+        { icon: Sparkles, label: '気分', value: `${status.mood}%`, color: 'text-amber-500' },
+        { icon: Database, label: '信頼', value: `${status.trust}%`, color: 'text-emerald-500' },
+        { icon: User, label: '親愛', value: `${status.friendliness || 0}%`, color: 'text-pink-500' },
     ];
 
     const profileStats = [
-        { label: 'Name', value: status.name || 'Reflecta' },
-        { label: 'Age', value: status.birthDate ? `${new Date().getFullYear() - new Date(status.birthDate).getFullYear()}歳` : 'Unknown' },
-        { label: 'Gender', value: status.gender || 'Unknown' },
-        { label: 'Type', value: status.chronotype || 'Unknown' },
-        { label: 'Intelligence', value: status.intelligence?.toString() || '?' },
+        { label: '名前', value: status.name || 'Reflecta' },
+        { label: '年齢', value: status.birthDate ? `${new Date().getFullYear() - new Date(status.birthDate).getFullYear()}歳` : 'Unknown' },
+        { label: '性別', value: status.gender || 'Unknown' },
+        { label: '朝型/夜型', value: status.chronotype || 'Unknown' },
+        { label: '相対知性(IQ)', value: status.intelligence?.toString() || '?' },
     ];
 
     const personalityStats = [
@@ -218,7 +218,7 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
 
                             {/* Condition Group */}
                             <div>
-                                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">Current Condition</h3>
+                                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1">今日の気分(Lv3-2)</h3>
                                 <div className="grid grid-cols-2 gap-2">
                                     {conditionStats.map((stat, i) => (
                                         <div key={i} className="bg-slate-50 dark:bg-slate-800/50 p-3 rounded-lg border border-slate-100 dark:border-slate-700/50 flex flex-col items-center">
@@ -233,7 +233,7 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                             {/* Profile Group */}
                             <div>
                                 <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <User className="w-3 h-3" /> Basic Profile
+                                    <User className="w-3 h-3" /> 基本情報(Lv1)
                                 </h3>
                                 <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-800 divide-y divide-slate-100 dark:divide-slate-800">
                                     {profileStats.map((stat, i) => (
@@ -245,25 +245,11 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                                 </div>
                             </div>
 
-                            {/* Body Stats */}
-                            <div>
-                                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <Activity className="w-3 h-3" /> 身体特性
-                                </h3>
-                                <div className="grid grid-cols-2 gap-2">
-                                    {bodyStats.map((stat, i) => (
-                                        <div key={i} className="flex justify-between p-2 bg-slate-50 dark:bg-slate-800/30 rounded border border-slate-100 dark:border-slate-800 text-xs">
-                                            <span className="text-slate-500">{stat.label}</span>
-                                            <span className="font-mono text-slate-700 dark:text-slate-300">{stat.value}</span>
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
 
                             {/* Personality Chart */}
                             <div>
                                 <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <Terminal className="w-3 h-3" /> 性格
+                                    <Terminal className="w-3 h-3" /> 性格(Lv2)
                                 </h3>
                                 <div className="space-y-3">
                                     {personalityStats.map((stat, i) => (
@@ -283,6 +269,22 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                                     ))}
                                 </div>
                             </div>
+
+                            {/* Body Stats */}
+                            <div>
+                                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
+                                    <Activity className="w-3 h-3" /> 身体特性(Lv3-1)
+                                </h3>
+                                <div className="grid grid-cols-2 gap-2">
+                                    {bodyStats.map((stat, i) => (
+                                        <div key={i} className="flex justify-between p-2 bg-slate-50 dark:bg-slate-800/30 rounded border border-slate-100 dark:border-slate-800 text-xs">
+                                            <span className="text-slate-500">{stat.label}</span>
+                                            <span className="font-mono text-slate-700 dark:text-slate-300">{stat.value}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+
                         </div>
                     ) : (
                         <div className="space-y-6">

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -21,6 +21,10 @@ interface PersonaStatus {
     height: number;
     weight: number;
     boneDensity?: number;
+    gripStrength?: number;
+    voicePitch?: number;
+    eyesight?: number;
+    hearingAbility?: number;
     bloodSugar?: number;
     bloodPressureSys?: number;
     bloodPressureDia?: number;
@@ -79,11 +83,23 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
         { label: '外向性', value: status.extroversion },
     ];
 
-    const bodyStats = [
-        { label: '身長', value: `${status.height}cm` },
-        { label: '体重', value: `${status.weight}kg` },
-        { label: '睡眠時間', value: `${status.sleepTime ?? '?'}h` },
+    // Lv2: 不可逆的成長データ
+    const growthStats = [
+        { label: '身長', value: `${status.height ?? '?'}cm` },
+        { label: '骨密度', value: `${status.boneDensity ?? '?'}` },
+        { label: '握力', value: `${status.gripStrength ?? '?'}kg` },
+        { label: '視力', value: `${status.eyesight ?? '?'}` },
+        { label: '聴力', value: `${status.hearingAbility ?? '?'}dB` },
+        { label: '声の高さ', value: `${status.voicePitch ?? '?'}Hz` },
+    ];
+
+    // Lv3-1: バイタルデータ
+    const vitalStats = [
+        { label: '体重', value: `${status.weight ?? '?'}kg` },
         { label: '血圧', value: `${status.bloodPressureSys ?? '?'}/${status.bloodPressureDia ?? '?'}` },
+        { label: '血糖値', value: `${status.bloodSugar ?? '?'}mg/dL` },
+        { label: '睡眠時間', value: `${status.sleepTime ?? '?'}h` },
+        { label: '睡眠の質', value: `${status.sleepQuality ?? '?'}%` },
     ];
 
     const handleStartEditName = () => {
@@ -270,13 +286,28 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
                                 </div>
                             </div>
 
-                            {/* Body Stats */}
+                            {/* Growth Stats (Lv2) */}
                             <div>
                                 <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
-                                    <Activity className="w-3 h-3" /> 身体特性(Lv3-1)
+                                    <Activity className="w-3 h-3" /> 身体成長(Lv2)
                                 </h3>
                                 <div className="grid grid-cols-2 gap-2">
-                                    {bodyStats.map((stat, i) => (
+                                    {growthStats.map((stat, i) => (
+                                        <div key={i} className="flex justify-between p-2 bg-slate-50 dark:bg-slate-800/30 rounded border border-slate-100 dark:border-slate-800 text-xs">
+                                            <span className="text-slate-500">{stat.label}</span>
+                                            <span className="font-mono text-slate-700 dark:text-slate-300">{stat.value}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Vital Stats (Lv3-1) */}
+                            <div>
+                                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 px-1 flex items-center gap-1">
+                                    <Heart className="w-3 h-3" /> バイタル(Lv3-1)
+                                </h3>
+                                <div className="grid grid-cols-2 gap-2">
+                                    {vitalStats.map((stat, i) => (
                                         <div key={i} className="flex justify-between p-2 bg-slate-50 dark:bg-slate-800/30 rounded border border-slate-100 dark:border-slate-800 text-xs">
                                             <span className="text-slate-500">{stat.label}</span>
                                             <span className="font-mono text-slate-700 dark:text-slate-300">{stat.value}</span>

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -45,9 +45,11 @@ type BotSidebarProps = {
     isOpen: boolean;
     status: PersonaStatus;
     lastDebugInfo: DebugInfo | null;
+    /** ステータス再取得コールバック（リロードせずにUIを更新するため） */
+    onStatusRefresh?: () => Promise<void>;
 };
 
-export function BotSidebar({ isOpen, status, lastDebugInfo }: BotSidebarProps) {
+export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: BotSidebarProps) {
     const [activeTab, setActiveTab] = useState<'status' | 'debug'>('status');
     const [editingName, setEditingName] = useState(status.name);
     const [isEditingName, setIsEditingName] = useState(false);
@@ -108,19 +110,15 @@ export function BotSidebar({ isOpen, status, lastDebugInfo }: BotSidebarProps) {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name: editingName })
             });
-            // Note: UI update relies on parent re-fetch or optimistically we could update local state if we had a handler
-            // For now, we assume reloading or next interaction updates it, or we rely on re-fetch.
-            // A page reload or context refresh might be needed to see changes immediately if status prop doesn't update.
-             window.location.reload(); // Simple brute force update for now as we don't have a refetch handler passed down
+            // 親コンポーネントからステータスを再取得（リロードせずにUIを更新）
+            if (onStatusRefresh) {
+                await onStatusRefresh();
+            }
         } catch (e) {
             console.error(e);
-            isSubmitting.current = false;
         } finally {
-            if (!isSubmitting.current) { // If reload didn't happen (error case)
-                 setIsEditingName(false);
-            }
-            // If success, reload happens, so state update might not matter, but for clear logic:
-            // isSubmitting.current = false; 
+            isSubmitting.current = false;
+            setIsEditingName(false);
         }
     };
     
@@ -134,7 +132,10 @@ export function BotSidebar({ isOpen, status, lastDebugInfo }: BotSidebarProps) {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ systemPrompt: editingSystemPromptText })
             });
-             window.location.reload(); 
+            // 親コンポーネントからステータスを再取得（リロードせずにUIを更新し、タブ状態を維持）
+            if (onStatusRefresh) {
+                await onStatusRefresh();
+            }
         } catch (e) {
             console.error(e);
         } finally {

--- a/frontend/src/components/BotSidebar.tsx
+++ b/frontend/src/components/BotSidebar.tsx
@@ -86,7 +86,7 @@ export function BotSidebar({ isOpen, status, lastDebugInfo, onStatusRefresh }: B
     // Lv2: 不可逆的成長データ
     const growthStats = [
         { label: '身長', value: `${status.height ?? '?'}cm` },
-        { label: '骨密度', value: `${status.boneDensity ?? '?'}` },
+        { label: '骨密度(YAM)', value: `${status.boneDensity ?? '?'}%` },
         { label: '握力', value: `${status.gripStrength ?? '?'}kg` },
         { label: '視力', value: `${status.eyesight ?? '?'}` },
         { label: '聴力', value: `${status.hearingAbility ?? '?'}dB` },

--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -352,6 +352,20 @@ export function ChatHistory({
                                             </p>
                                         )}
                                     </div>
+                                    <div>
+                                        <span className="text-slate-400 block mb-1">New Memories</span>
+                                        {lastReflection.response?.newMemories && lastReflection.response.newMemories.length > 0 ? (
+                                            <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 text-xs bg-white dark:bg-slate-800 p-2 rounded border border-slate-100 dark:border-slate-700">
+                                                {lastReflection.response.newMemories.map((mem, i) => (
+                                                    <li key={i}>{mem}</li>
+                                                ))}
+                                            </ul>
+                                        ) : (
+                                            <p className="text-slate-400 dark:text-slate-600 text-xs italic pl-1">
+                                                No new memories recorded.
+                                            </p>
+                                        )}
+                                    </div>
                                 </motion.div>
                             )}
                         </motion.div>

--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -335,13 +335,13 @@ export function ChatHistory({
                                         )}
                                     </div>
                                     <div>
-                                        <span className="text-slate-400 block mb-1">Thought</span>
+                                        <span className="text-slate-400 block mb-1">考えたこと</span>
                                         <p className="text-slate-600 dark:text-slate-300 leading-relaxed bg-white dark:bg-slate-800 p-2 rounded border border-slate-100 dark:border-slate-700">
                                             {lastReflection.response?.thought || "No thought available"}
                                         </p>
                                     </div>
                                     <div>
-                                        <span className="text-slate-400 block mb-1">New Memory</span>
+                                        <span className="text-slate-400 block mb-1">ずっと覚えておくべきこと</span>
                                         {lastReflection.response?.permanentMemory ? (
                                             <p className="text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 p-2 rounded border border-amber-100 dark:border-amber-900/50">
                                                 {lastReflection.response.permanentMemory}
@@ -353,7 +353,7 @@ export function ChatHistory({
                                         )}
                                     </div>
                                     <div>
-                                        <span className="text-slate-400 block mb-1">New Memories</span>
+                                        <span className="text-slate-400 block mb-1">新しい発見</span>
                                         {lastReflection.response?.newMemories && lastReflection.response.newMemories.length > 0 ? (
                                             <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 text-xs bg-white dark:bg-slate-800 p-2 rounded border border-slate-100 dark:border-slate-700">
                                                 {lastReflection.response.newMemories.map((mem, i) => (

--- a/frontend/src/components/PersonaCreationModal.tsx
+++ b/frontend/src/components/PersonaCreationModal.tsx
@@ -189,7 +189,7 @@ export function PersonaCreationModal({ isOpen, onClose, onCreated }: PersonaCrea
                             </div>
                             
                             <div>
-                                <label className="block text-xs font-medium text-slate-700 dark:text-slate-300 mb-1">知能指数 (IQ)</label>
+                                <label className="block text-xs font-medium text-slate-700 dark:text-slate-300 mb-1">相対知能 (IQ)</label>
                                 <input 
                                     type="number" 
                                     value={intelligence}
@@ -260,7 +260,7 @@ export function PersonaCreationModal({ isOpen, onClose, onCreated }: PersonaCrea
                                 <label className="block text-xs font-medium text-slate-700 dark:text-slate-300 mb-1">System Prompt</label>
                                 <p className="text-[10px] text-slate-500 mb-2">
                                     AIに対する追加の振る舞い指示や設定を入力できます。
-                                    （例: 「語尾に『にゃん』をつけて話して」「常に敬語を使って」「関西弁で話して」など）
+                                    （Note: 一応、デバッグ用の機能です。将来的には廃止し、AI側で性格を自己変化させるようにさせたい）
                                 </p>
                                 <textarea
                                     value={systemPrompt}

--- a/frontend/src/components/PersonaCreationModal.tsx
+++ b/frontend/src/components/PersonaCreationModal.tsx
@@ -28,10 +28,22 @@ export function PersonaCreationModal({ isOpen, onClose, onCreated }: PersonaCrea
         extroversion: 50
     });
 
-    // Vital
+    // Vital（Lv2: 身体成長データ + Lv3-1: バイタルデータ）
     const [vitalData, setVitalData] = useState({
+        // Lv2: 身体成長（不可逆）
         height: 160,
-        weight: 50
+        boneDensity: 100,
+        gripStrength: 30,
+        eyesight: 1.0,
+        hearingAbility: 20,
+        voicePitch: 250,
+        // Lv3-1: バイタル（可逆）
+        weight: 50,
+        bloodPressureSys: 110,
+        bloodPressureDia: 70,
+        bloodSugar: 90,
+        sleepTime: 7,
+        sleepQuality: 70,
     });
     
     // System Prompt
@@ -43,7 +55,7 @@ export function PersonaCreationModal({ isOpen, onClose, onCreated }: PersonaCrea
         setBirthDate('2024-01-01');
         setIntelligence(100);
         setPersonality({ ethics: 50, passion: 50, curiosity: 50, aggressiveness: 50, extroversion: 50 });
-        setVitalData({ height: 160, weight: 50 });
+        setVitalData({ height: 160, boneDensity: 100, gripStrength: 30, eyesight: 1.0, hearingAbility: 20, voicePitch: 250, weight: 50, bloodPressureSys: 110, bloodPressureDia: 70, bloodSugar: 90, sleepTime: 7, sleepQuality: 70 });
         setStep(1);
     };
 
@@ -219,6 +231,106 @@ export function PersonaCreationModal({ isOpen, onClose, onCreated }: PersonaCrea
                                             className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
                                         />
                                     </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">骨密度 YAM (%)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.boneDensity}
+                                            onChange={(e) => setVitalData({...vitalData, boneDensity: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">握力 (kg)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.gripStrength}
+                                            onChange={(e) => setVitalData({...vitalData, gripStrength: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">視力</label>
+                                        <input 
+                                            type="number" 
+                                            step="0.1"
+                                            value={vitalData.eyesight}
+                                            onChange={(e) => setVitalData({...vitalData, eyesight: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">聴力 (dB)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.hearingAbility}
+                                            onChange={(e) => setVitalData({...vitalData, hearingAbility: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">声の高さ (Hz)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.voicePitch}
+                                            onChange={(e) => setVitalData({...vitalData, voicePitch: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Lv3-1: 生体データ */}
+                            <div>
+                                <h4 className="text-xs font-bold text-slate-400 mt-4 mb-2 flex items-center gap-1"><Activity className="w-3 h-3"/> 生体データ</h4>
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">最高血圧 (収縮期/mmHg)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.bloodPressureSys}
+                                            onChange={(e) => setVitalData({...vitalData, bloodPressureSys: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">最低血圧 (拡張期/mmHg)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.bloodPressureDia}
+                                            onChange={(e) => setVitalData({...vitalData, bloodPressureDia: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">空腹時血糖値 (mg/dL)</label>
+                                        <input 
+                                            type="number" 
+                                            value={vitalData.bloodSugar}
+                                            onChange={(e) => setVitalData({...vitalData, bloodSugar: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">睡眠時間 (h)</label>
+                                        <input 
+                                            type="number" 
+                                            step="0.5"
+                                            value={vitalData.sleepTime}
+                                            onChange={(e) => setVitalData({...vitalData, sleepTime: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-[10px] text-slate-500 mb-1">睡眠の質 (%)</label>
+                                        <input 
+                                            type="number" 
+                                            min="0" max="100"
+                                            value={vitalData.sleepQuality}
+                                            onChange={(e) => setVitalData({...vitalData, sleepQuality: Number(e.target.value)})}
+                                            className="w-full p-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded outline-none text-sm"
+                                        />
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -232,21 +344,31 @@ export function PersonaCreationModal({ isOpen, onClose, onCreated }: PersonaCrea
                             </h3>
 
                             <div className="space-y-4">
-                                {Object.entries(personality).map(([key, val]) => (
-                                    <div key={key}>
-                                        <div className="flex justify-between text-xs mb-1">
-                                            <span className="capitalize text-slate-700 dark:text-slate-300">{key}</span>
-                                            <span className="text-slate-500">{val}</span>
+                                {Object.entries(personality).map(([key, val]) => {
+                                    /** 性格パラメータキーと日本語ラベルの対応マップ */
+                                    const labelMap: Record<string, string> = {
+                                        ethics: '倫理観',
+                                        passion: '情熱',
+                                        curiosity: '好奇心',
+                                        aggressiveness: '攻撃性',
+                                        extroversion: '外向性',
+                                    };
+                                    return (
+                                        <div key={key}>
+                                            <div className="flex justify-between text-xs mb-1">
+                                                <span className="text-slate-700 dark:text-slate-300">{labelMap[key] || key}</span>
+                                                <span className="text-slate-500">{val}</span>
+                                            </div>
+                                            <input 
+                                                type="range" 
+                                                min="0" max="100" 
+                                                value={val}
+                                                onChange={(e) => setPersonality({...personality, [key]: Number(e.target.value)})}
+                                                className="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-purple-600"
+                                            />
                                         </div>
-                                        <input 
-                                            type="range" 
-                                            min="0" max="100" 
-                                            value={val}
-                                            onChange={(e) => setPersonality({...personality, [key]: Number(e.target.value)})}
-                                            className="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-purple-600"
-                                        />
-                                    </div>
-                                ))}
+                                    );
+                                })}
                             </div>
                         </div>
                     )}

--- a/frontend/src/components/PersonaLogTab.tsx
+++ b/frontend/src/components/PersonaLogTab.tsx
@@ -1,0 +1,512 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Activity, TrendingUp, AlertCircle, RefreshCw } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Legend,
+    ResponsiveContainer,
+} from 'recharts';
+
+const API_URL = import.meta.env.VITE_API_URL || '';
+
+/**
+ * 不可逆データのフィールド定義
+ * グラフ表示用のラベルと色を管理
+ */
+const IRREVERSIBLE_FIELDS = [
+    { key: 'height', label: '身長 (cm)', color: '#3b82f6' },
+    { key: 'boneDensity', label: '骨密度', color: '#10b981' },
+    { key: 'gripStrength', label: '握力 (kg)', color: '#f59e0b' },
+    { key: 'voicePitch', label: '声の高さ (Hz)', color: '#8b5cf6' },
+    { key: 'eyesight', label: '視力', color: '#ef4444' },
+    { key: 'hearingAbility', label: '聴力 (dB)', color: '#06b6d4' },
+];
+
+/**
+ * 感情・状態データのフィールド定義
+ */
+const EMOTION_FIELDS = [
+    { key: 'mood', label: '気分', color: '#f59e0b' },
+    { key: 'trust', label: '信頼度', color: '#3b82f6' },
+    { key: 'health', label: '健康', color: '#10b981' },
+    { key: 'friendliness', label: '友好度', color: '#8b5cf6' },
+];
+
+interface PersonaLogTabProps {
+    /** 現在選択中のペルソナID */
+    currentPersonaId: string | null;
+}
+
+/** 不可逆ステータスレコードの型 */
+interface IrreversibleRecord {
+    id: string;
+    version: number;
+    height: number | null;
+    boneDensity: number | null;
+    gripStrength: number | null;
+    voicePitch: number | null;
+    eyesight: number | null;
+    hearingAbility: number | null;
+    recordedAt: string;
+}
+
+/** 感情データ（JSON value）の1項目 */
+interface EmotionDataItem {
+    label: string;
+    value: number;
+    unit: string | null;
+}
+
+/** 可逆半定量ステータスレコードの型 */
+interface SemiquantityRecord {
+    id: string;
+    version: number;
+    value: EmotionDataItem[];
+    recordedAt: string;
+}
+
+/**
+ * 人格ログタブコンポーネント
+ * ペルソナの不可逆データと感情データの時系列グラフを表示する
+ */
+export function PersonaLogTab({ currentPersonaId }: PersonaLogTabProps) {
+    const [irreversibleData, setIrreversibleData] = useState<IrreversibleRecord[]>([]);
+    const [semiquantityData, setSemiquantityData] = useState<SemiquantityRecord[]>([]);
+    const [personaName, setPersonaName] = useState<string>('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    /** 不可逆データで表示するフィールドの選択状態 */
+    const [activeFields, setActiveFields] = useState<Set<string>>(new Set(['height', 'boneDensity']));
+    /** 感情データで表示するフィールドの選択状態 */
+    const [activeEmotionFields, setActiveEmotionFields] = useState<Set<string>>(new Set(['mood', 'trust', 'health']));
+
+    /**
+     * ペルソナの履歴データを取得する
+     */
+    const fetchHistory = async () => {
+        if (!currentPersonaId) return;
+        setIsLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get(`${API_URL}/api/personas/${currentPersonaId}/history`);
+            setIrreversibleData(res.data.irreversibleHistory || []);
+            setSemiquantityData(res.data.semiquantityHistory || []);
+            setPersonaName(res.data.personaName || '');
+        } catch (err) {
+            console.error('[PersonaLogTab] Failed to fetch history:', err);
+            setError('履歴データの取得に失敗しました');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchHistory();
+    }, [currentPersonaId]);
+
+    /**
+     * 不可逆データをグラフ用にフォーマット
+     * 横軸を記録回数（版数）にする
+     */
+    const formatIrreversibleChartData = () => {
+        return irreversibleData.map((record, index) => ({
+            index: index + 1,
+            version: record.version,
+            date: new Date(record.recordedAt).toLocaleDateString('ja-JP', {
+                month: 'short',
+                day: 'numeric',
+            }),
+            height: record.height,
+            boneDensity: record.boneDensity,
+            gripStrength: record.gripStrength,
+            voicePitch: record.voicePitch,
+            eyesight: record.eyesight,
+            hearingAbility: record.hearingAbility,
+        }));
+    };
+
+    /**
+     * 感情データをグラフ用にフォーマット
+     */
+    const formatEmotionChartData = () => {
+        return semiquantityData.map((record, index) => {
+            const dataPoint: Record<string, number | string | null> = {
+                index: index + 1,
+                version: record.version,
+                date: new Date(record.recordedAt).toLocaleDateString('ja-JP', {
+                    month: 'short',
+                    day: 'numeric',
+                }),
+            };
+            // JSON value 配列から各フィールドを展開
+            if (Array.isArray(record.value)) {
+                record.value.forEach((item: EmotionDataItem) => {
+                    dataPoint[item.label] = item.value;
+                });
+            }
+            return dataPoint;
+        });
+    };
+
+    /**
+     * フィールドの表示/非表示をトグルする
+     */
+    const toggleField = (key: string) => {
+        setActiveFields(prev => {
+            const next = new Set(prev);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+    };
+
+    /**
+     * 感情フィールドの表示/非表示をトグルする
+     */
+    const toggleEmotionField = (key: string) => {
+        setActiveEmotionFields(prev => {
+            const next = new Set(prev);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+    };
+
+    if (!currentPersonaId) {
+        return (
+            <div className="flex-1 flex items-center justify-center text-slate-400 dark:text-slate-600">
+                <p>ペルソナを選択してください</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 overflow-y-auto px-6 py-6 scrollbar-thin">
+            <div className="w-full max-w-[900px] mx-auto space-y-8">
+                {/* ヘッダー */}
+                <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    className="flex items-center justify-between"
+                >
+                    <div className="flex items-center gap-3">
+                        <div className="p-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-xl">
+                            <Activity className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
+                        </div>
+                        <div>
+                            <h2 className="text-xl font-bold text-slate-800 dark:text-slate-100">
+                                {personaName || 'Persona'} の人格ログ
+                            </h2>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                                不可逆データと感情データの時系列変化
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        onClick={fetchHistory}
+                        disabled={isLoading}
+                        className="p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg transition-colors disabled:opacity-50"
+                        title="データを更新"
+                    >
+                        <RefreshCw className={`w-5 h-5 text-slate-500 ${isLoading ? 'animate-spin' : ''}`} />
+                    </button>
+                </motion.div>
+
+                {/* エラー表示 */}
+                <AnimatePresence>
+                    {error && (
+                        <motion.div
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: 'auto' }}
+                            exit={{ opacity: 0, height: 0 }}
+                            className="flex items-center gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-600 dark:text-red-400 text-sm"
+                        >
+                            <AlertCircle className="w-4 h-4 flex-shrink-0" />
+                            {error}
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+
+                {/* ローディング */}
+                {isLoading && (
+                    <div className="flex items-center justify-center py-12">
+                        <div className="flex gap-2">
+                            <span className="w-2 h-2 bg-indigo-500 rounded-full animate-bounce" />
+                            <span className="w-2 h-2 bg-indigo-500 rounded-full animate-bounce [animation-delay:0.2s]" />
+                            <span className="w-2 h-2 bg-indigo-500 rounded-full animate-bounce [animation-delay:0.4s]" />
+                        </div>
+                    </div>
+                )}
+
+                {/* 不可逆データ（Lv2）グラフセクション */}
+                {!isLoading && (
+                    <motion.div
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: 0.1 }}
+                        className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm"
+                    >
+                        <div className="flex items-center gap-2 mb-4">
+                            <TrendingUp className="w-5 h-5 text-blue-500" />
+                            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                                不可逆的成長データ (Lv2)
+                            </h3>
+                        </div>
+                        <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">
+                            身長・骨密度・握力など、加齢や経験に伴い蓄積的に変化する指標
+                        </p>
+
+                        {/* フィールドフィルター */}
+                        <div className="flex flex-wrap gap-2 mb-6">
+                            {IRREVERSIBLE_FIELDS.map(field => (
+                                <button
+                                    key={field.key}
+                                    onClick={() => toggleField(field.key)}
+                                    className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-200 border ${
+                                        activeFields.has(field.key)
+                                            ? 'text-white shadow-sm'
+                                            : 'bg-transparent text-slate-500 dark:text-slate-400 border-slate-300 dark:border-slate-700 hover:border-slate-400'
+                                    }`}
+                                    style={
+                                        activeFields.has(field.key)
+                                            ? { backgroundColor: field.color, borderColor: field.color }
+                                            : {}
+                                    }
+                                >
+                                    {field.label}
+                                </button>
+                            ))}
+                        </div>
+
+                        {/* グラフ本体 */}
+                        {irreversibleData.length > 0 ? (
+                            <div className="h-[300px]">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <LineChart data={formatIrreversibleChartData()}>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="var(--border-color)" />
+                                        <XAxis
+                                            dataKey="index"
+                                            label={{ value: '記録回数', position: 'insideBottomRight', offset: -5, fontSize: 12 }}
+                                            tick={{ fontSize: 11 }}
+                                            stroke="var(--text-secondary)"
+                                        />
+                                        <YAxis
+                                            tick={{ fontSize: 11 }}
+                                            stroke="var(--text-secondary)"
+                                        />
+                                        <Tooltip
+                                            contentStyle={{
+                                                backgroundColor: 'var(--bg-card)',
+                                                border: '1px solid var(--border-color)',
+                                                borderRadius: '12px',
+                                                fontSize: '12px',
+                                                boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                                            }}
+                                            labelFormatter={(value) => `記録 #${value}`}
+                                        />
+                                        <Legend
+                                            wrapperStyle={{ fontSize: '12px' }}
+                                        />
+                                        {IRREVERSIBLE_FIELDS.filter(f => activeFields.has(f.key)).map(field => (
+                                            <Line
+                                                key={field.key}
+                                                type="monotone"
+                                                dataKey={field.key}
+                                                name={field.label}
+                                                stroke={field.color}
+                                                strokeWidth={2}
+                                                dot={{ r: 4, fill: field.color }}
+                                                activeDot={{ r: 6 }}
+                                                connectNulls
+                                            />
+                                        ))}
+                                    </LineChart>
+                                </ResponsiveContainer>
+                            </div>
+                        ) : (
+                            <div className="flex flex-col items-center justify-center py-12 text-slate-400 dark:text-slate-600">
+                                <Activity className="w-10 h-10 mb-2 opacity-30" />
+                                <p className="text-sm">まだ記録されたデータがありません</p>
+                                <p className="text-xs mt-1">内省処理を実行すると記録が蓄積されます</p>
+                            </div>
+                        )}
+                    </motion.div>
+                )}
+
+                {/* 感情データ（Lv3-2）グラフセクション */}
+                {!isLoading && (
+                    <motion.div
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: 0.2 }}
+                        className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm"
+                    >
+                        <div className="flex items-center gap-2 mb-4">
+                            <TrendingUp className="w-5 h-5 text-amber-500" />
+                            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                                感情・状態データ (Lv3-2)
+                            </h3>
+                        </div>
+                        <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">
+                            気分・信頼度・健康・友好度など、対話を通じて変化する感情指標
+                        </p>
+
+                        {/* フィールドフィルター */}
+                        <div className="flex flex-wrap gap-2 mb-6">
+                            {EMOTION_FIELDS.map(field => (
+                                <button
+                                    key={field.key}
+                                    onClick={() => toggleEmotionField(field.key)}
+                                    className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-200 border ${
+                                        activeEmotionFields.has(field.key)
+                                            ? 'text-white shadow-sm'
+                                            : 'bg-transparent text-slate-500 dark:text-slate-400 border-slate-300 dark:border-slate-700 hover:border-slate-400'
+                                    }`}
+                                    style={
+                                        activeEmotionFields.has(field.key)
+                                            ? { backgroundColor: field.color, borderColor: field.color }
+                                            : {}
+                                    }
+                                >
+                                    {field.label}
+                                </button>
+                            ))}
+                        </div>
+
+                        {/* グラフ本体 */}
+                        {semiquantityData.length > 0 ? (
+                            <div className="h-[300px]">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <LineChart data={formatEmotionChartData()}>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="var(--border-color)" />
+                                        <XAxis
+                                            dataKey="index"
+                                            label={{ value: '記録回数', position: 'insideBottomRight', offset: -5, fontSize: 12 }}
+                                            tick={{ fontSize: 11 }}
+                                            stroke="var(--text-secondary)"
+                                        />
+                                        <YAxis
+                                            tick={{ fontSize: 11 }}
+                                            stroke="var(--text-secondary)"
+                                            domain={[0, 100]}
+                                        />
+                                        <Tooltip
+                                            contentStyle={{
+                                                backgroundColor: 'var(--bg-card)',
+                                                border: '1px solid var(--border-color)',
+                                                borderRadius: '12px',
+                                                fontSize: '12px',
+                                                boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                                            }}
+                                            labelFormatter={(value) => `記録 #${value}`}
+                                        />
+                                        <Legend
+                                            wrapperStyle={{ fontSize: '12px' }}
+                                        />
+                                        {EMOTION_FIELDS.filter(f => activeEmotionFields.has(f.key)).map(field => (
+                                            <Line
+                                                key={field.key}
+                                                type="monotone"
+                                                dataKey={field.key}
+                                                name={field.label}
+                                                stroke={field.color}
+                                                strokeWidth={2}
+                                                dot={{ r: 4, fill: field.color }}
+                                                activeDot={{ r: 6 }}
+                                                connectNulls
+                                            />
+                                        ))}
+                                    </LineChart>
+                                </ResponsiveContainer>
+                            </div>
+                        ) : (
+                            <div className="flex flex-col items-center justify-center py-12 text-slate-400 dark:text-slate-600">
+                                <Activity className="w-10 h-10 mb-2 opacity-30" />
+                                <p className="text-sm">まだ記録されたデータがありません</p>
+                                <p className="text-xs mt-1">内省処理を実行すると感情データが蓄積されます</p>
+                            </div>
+                        )}
+                    </motion.div>
+                )}
+
+                {/* データ概要テーブル */}
+                {!isLoading && irreversibleData.length > 0 && (
+                    <motion.div
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: 0.3 }}
+                        className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-sm"
+                    >
+                        <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100 mb-4">
+                            記録一覧
+                        </h3>
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="border-b border-slate-200 dark:border-slate-700">
+                                        <th className="text-left py-2 px-3 text-slate-500 dark:text-slate-400 font-medium">#</th>
+                                        <th className="text-left py-2 px-3 text-slate-500 dark:text-slate-400 font-medium">日時</th>
+                                        {IRREVERSIBLE_FIELDS.map(f => (
+                                            <th key={f.key} className="text-right py-2 px-3 text-slate-500 dark:text-slate-400 font-medium">
+                                                {f.label}
+                                            </th>
+                                        ))}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {irreversibleData.map((record, index) => (
+                                        <tr
+                                            key={record.id}
+                                            className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
+                                        >
+                                            <td className="py-2 px-3 text-slate-600 dark:text-slate-300">{index + 1}</td>
+                                            <td className="py-2 px-3 text-slate-600 dark:text-slate-300">
+                                                {new Date(record.recordedAt).toLocaleString('ja-JP', {
+                                                    year: 'numeric',
+                                                    month: '2-digit',
+                                                    day: '2-digit',
+                                                    hour: '2-digit',
+                                                    minute: '2-digit',
+                                                })}
+                                            </td>
+                                            <td className="text-right py-2 px-3 text-slate-700 dark:text-slate-200 font-mono">
+                                                {record.height ?? '-'}
+                                            </td>
+                                            <td className="text-right py-2 px-3 text-slate-700 dark:text-slate-200 font-mono">
+                                                {record.boneDensity ?? '-'}
+                                            </td>
+                                            <td className="text-right py-2 px-3 text-slate-700 dark:text-slate-200 font-mono">
+                                                {record.gripStrength ?? '-'}
+                                            </td>
+                                            <td className="text-right py-2 px-3 text-slate-700 dark:text-slate-200 font-mono">
+                                                {record.voicePitch ?? '-'}
+                                            </td>
+                                            <td className="text-right py-2 px-3 text-slate-700 dark:text-slate-200 font-mono">
+                                                {record.eyesight ?? '-'}
+                                            </td>
+                                            <td className="text-right py-2 px-3 text-slate-700 dark:text-slate-200 font-mono">
+                                                {record.hearingAbility ?? '-'}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </motion.div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/PersonaSelector.tsx
+++ b/frontend/src/components/PersonaSelector.tsx
@@ -1,0 +1,195 @@
+import { useState, useRef, useEffect } from 'react';
+import { Bot, ChevronDown, PlusCircle, Check } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+/**
+ * ペルソナの基本情報
+ */
+interface Persona {
+    id: string;
+    name: string;
+}
+
+/**
+ * PersonaSelector コンポーネントの Props
+ */
+interface PersonaSelectorProps {
+    /** 利用可能なペルソナ一覧 */
+    personas: Persona[];
+    /** 現在選択中のペルソナID */
+    currentPersonaId: string | null;
+    /** ペルソナ選択時のコールバック */
+    onSelect: (personaId: string) => void;
+    /** 新規ペルソナ作成ボタン押下時のコールバック */
+    onCreateNew: () => void;
+}
+
+/**
+ * カスタムドロップダウン形式のペルソナセレクター
+ *
+ * ネイティブの <select> を置き換え、アイコン・区切り線・Framer Motion のアニメーション付きで
+ * リッチなUIを提供する。外側クリックで自動的に閉じる。
+ */
+export function PersonaSelector({
+    personas,
+    currentPersonaId,
+    onSelect,
+    onCreateNew,
+}: PersonaSelectorProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    /** 現在選択中のペルソナ名を取得 */
+    const currentPersona = personas.find((p) => p.id === currentPersonaId);
+
+    /**
+     * ドロップダウン外側のクリックを検知して閉じる
+     */
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [isOpen]);
+
+    /**
+     * ペルソナ選択ハンドラ
+     */
+    const handleSelect = (personaId: string) => {
+        onSelect(personaId);
+        setIsOpen(false);
+    };
+
+    /**
+     * 新規作成ハンドラ
+     */
+    const handleCreateNew = () => {
+        onCreateNew();
+        setIsOpen(false);
+    };
+
+    return (
+        <div ref={containerRef} className="relative ml-4">
+            {/* トリガーボタン */}
+            <button
+                onClick={() => setIsOpen(!isOpen)}
+                className={`
+                    flex items-center gap-2 pl-3 pr-2.5 py-1.5
+                    bg-blue-50 dark:bg-slate-800
+                    border border-blue-200 dark:border-slate-700
+                    rounded-lg text-sm font-medium
+                    text-slate-700 dark:text-slate-200
+                    hover:bg-blue-100 dark:hover:bg-slate-700
+                    focus:ring-2 focus:ring-blue-500 focus:outline-none
+                    transition-colors cursor-pointer
+                `}
+            >
+                <Bot className="w-4 h-4 text-blue-500 dark:text-blue-400 shrink-0" />
+                <span className="truncate max-w-[140px]">
+                    {currentPersona?.name || 'ペルソナ未選択'}
+                </span>
+                <ChevronDown
+                    className={`w-4 h-4 text-slate-400 shrink-0 transition-transform duration-200 ${
+                        isOpen ? 'rotate-180' : ''
+                    }`}
+                />
+            </button>
+
+            {/* ドロップダウンメニュー */}
+            <AnimatePresence>
+                {isOpen && (
+                    <motion.div
+                        initial={{ opacity: 0, y: -4, scale: 0.97 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: -4, scale: 0.97 }}
+                        transition={{ duration: 0.15, ease: 'easeOut' }}
+                        className="
+                            absolute top-full left-0 mt-1.5 z-50
+                            min-w-[220px] w-max
+                            bg-white dark:bg-slate-900
+                            border border-slate-200 dark:border-slate-700
+                            rounded-xl shadow-xl shadow-slate-200/50 dark:shadow-slate-900/50
+                            overflow-hidden
+                        "
+                    >
+                        {/* ペルソナリスト */}
+                        <div className="py-1.5 max-h-60 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-200 dark:scrollbar-thumb-slate-700">
+                            {personas.length === 0 ? (
+                                <div className="px-4 py-3 text-sm text-slate-400 italic text-center">
+                                    ペルソナがありません
+                                </div>
+                            ) : (
+                                personas.map((persona) => {
+                                    const isSelected = persona.id === currentPersonaId;
+                                    return (
+                                        <button
+                                            key={persona.id}
+                                            onClick={() => handleSelect(persona.id)}
+                                            className={`
+                                                w-full flex items-center gap-2.5 px-3.5 py-2 text-sm text-left
+                                                transition-colors duration-100
+                                                ${isSelected
+                                                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                                                    : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800'
+                                                }
+                                            `}
+                                        >
+                                            {/* ペルソナアイコン */}
+                                            <span
+                                                className={`
+                                                    w-7 h-7 rounded-full flex items-center justify-center shrink-0
+                                                    ${isSelected
+                                                        ? 'bg-blue-500 text-white'
+                                                        : 'bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500'
+                                                    }
+                                                `}
+                                            >
+                                                <Bot className="w-3.5 h-3.5" />
+                                            </span>
+
+                                            {/* ペルソナ名 */}
+                                            <span className="flex-1 truncate font-medium">
+                                                {persona.name}
+                                            </span>
+
+                                            {/* 選択中マーク */}
+                                            {isSelected && (
+                                                <Check className="w-4 h-4 text-blue-500 dark:text-blue-400 shrink-0" />
+                                            )}
+                                        </button>
+                                    );
+                                })
+                            )}
+                        </div>
+
+                        {/* 区切り線 */}
+                        <div className="border-t border-slate-100 dark:border-slate-800" />
+
+                        {/* 新規作成ボタン */}
+                        <div className="p-1.5">
+                            <button
+                                onClick={handleCreateNew}
+                                className="
+                                    w-full flex items-center gap-2.5 px-3.5 py-2 text-sm
+                                    text-blue-600 dark:text-blue-400 font-medium
+                                    hover:bg-blue-50 dark:hover:bg-blue-900/20
+                                    rounded-lg transition-colors duration-100
+                                "
+                            >
+                                <span className="w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center shrink-0">
+                                    <PlusCircle className="w-3.5 h-3.5" />
+                                </span>
+                                <span>新しいペルソナを作成</span>
+                            </button>
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}


### PR DESCRIPTION
#24: input要素をtextareaに変更し、Shift+Enterで改行、Enterで送信に対応 #14: メッセージにcreatedAtを付与し、吹き出し下に時刻(HH:MM)を表示
#38: メインエリアにChat/人格ログのタブを追加。人格ログタブでは
     不可逆データ(Lv2)と感情データ(Lv3-2)の時系列グラフを表示

新規ファイル:
- backend/src/app/api/personas/[id]/history/route.ts (履歴API)
- frontend/src/components/PersonaLogTab.tsx (人格ログコンポーネント)

追加パッケージ: recharts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 変更の主目的
  - チャット入力・表示のUX改善（textarea化、Shift+Enterで改行、Enterで送信、メッセージ時刻表示(createdAt)）
  - チャット履歴のページネーション導入（カーソルベース）と無限スクロール風の履歴取得
  - ペルソナの時系列データ可視化機能を追加（「人格ログ」タブでLv2・Lv3-2をグラフ表示）
  - ペルソナステータスの拡張（gripStrength, voicePitch, eyesight, hearingAbility など）および初期値の改善
  - フロントのコンポーネント分割とUI日本語化、依存ライブラリ(recharts)追加

- 影響範囲（主な変更ファイル・モジュール）
  - バックエンド
    - backend/src/app/api/personas/[id]/history/route.ts（新規）：ペルソナ履歴取得API
    - backend/src/app/api/chats/[id]/route.ts：チャット履歴のカーソルベースページネーション、初回のみlatestReflection/status取得に変更
    - backend/src/app/api/personas/route.ts：Lv2/Lv3-1初期値をvitalData由来に変更、boneDensityデフォルト更新ほかフィールド追加
    - backend/src/app/api/reflect/route.ts：irreversibleDataに新フィールド追加およびboneDensityデフォルト更新
    - backend/src/lib/persona.ts：flattenStatusへ新しいLv2フィールド（gripStrength, voicePitch, eyesight, hearingAbility）を含める
  - フロントエンド
    - frontend/src/App.tsx（大幅変更）：MessageにcreatedAt追加、PersonaStatus拡張、チャット/人格ログタブ導入、ページネーション／スクロール管理、日付ラベル処理、textarea自動リサイズ・キーボード挙動
    - frontend/src/components/PersonaLogTab.tsx（新規）：時系列グラフ表示（recharts）・フィールドトグル・データテーブル
    - frontend/src/components/PersonaSelector.tsx（新規）：ペルソナ選択ドロップダウン
    - frontend/src/components/BotSidebar.tsx：PersonaStatus型拡張、onStatusRefreshコールバック追加、表示構成の再編（日本語ラベル）
    - frontend/src/components/PersonaCreationModal.tsx：vital/bodyデータの入力項目拡張・UI調整
    - frontend/src/components/ChatHistory.tsx：反省表示ラベルの日本語化＋新規発見ブロック
    - frontend/package.json：依存追加（recharts ^3.7.0）
  - その他
    - GEMINI.md：Co-authored-byトレーラー等のドキュメント修正（機能への影響なし）

- 留意点 / レビュー上の注目箇所
  - チャット履歴のカーソルページネーションとフロントの無限スクロール連携（nextCursor/hasMoreの整合性）
  - createdAt導入に伴う既存データ互換性と表示ロジック（日時フォーマット・日付ラベル挿入）
  - 新規ペルソナフィールドの初期化・反映（バックエンドでのデフォルト値とフロントの表示/編集フォームの整合性）
  - PersonaLogTabでのデータ整形・グラフ表示（recharts依存とパフォーマンス）
  - onStatusRefreshコールバック導入による既存フローの副作用（ページ再読み込みからコールバック更新へ移行）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->