### PR TITLE
グラフ表示改善、マルチペルソナ

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,8 +46,10 @@ model Persona {
   reflectionEvents ReflectionEvent[]
   /// ペルソナの生成日時
   createdAt        DateTime          @default(now())
-  /// ペルソナが参加しているチャットセッション
-  chats            Chat[]
+  /// ペルソナがメインとして参加しているチャットセッション
+  chats            Chat[]            @relation("MainPersonaChats")
+  /// ペルソナがゲストとして参加しているチャットセッション
+  additionalChats  Chat[]            @relation("AdditionalPersonaChats")
 
   @@map("personas")
 }
@@ -195,21 +197,26 @@ model SemiquantityReversibleStatus {
 
 /// チャットセッション。ユーザーとペルソナの対話をまとめる単位。
 model Chat {
-  id        String    @id @default(uuid())
+  id                  String    @id @default(uuid())
   /// セッションのタイトル
-  title     String    @default("New Chat")
+  title               String    @default("New Chat")
   /// 参加しているユーザー
-  userId    String
-  user      User      @relation(fields: [userId], references: [id])
-  /// 参加しているペルソナ
-  personaId String
-  persona   Persona   @relation(fields: [personaId], references: [id])
+  userId              String
+  user                User      @relation(fields: [userId], references: [id])
+  /// 参加しているメインペルソナ
+  personaId           String
+  persona             Persona   @relation("MainPersonaChats", fields: [personaId], references: [id])
+  /// 参加している追加ペルソナ（実験的機能：ペルソナ同士の対話用など）
+  additionalPersonaId String?
+  additionalPersona   Persona?  @relation("AdditionalPersonaChats", fields: [additionalPersonaId], references: [id])
+  /// チャットセッションのメタデータや設定値（例: {"mode": "persona_interaction"}）
+  options             Json?
   /// セッション開始日時
-  createdAt DateTime  @default(now())
+  createdAt           DateTime  @default(now())
   /// 最後に発言があった日時
-  updatedAt DateTime  @updatedAt
+  updatedAt           DateTime  @updatedAt
   /// このセッションに紐づく個別の発言
-  chatLogs  ChatLog[]
+  chatLogs            ChatLog[]
 
   @@map("chats")
 }

--- a/backend/src/app/api/chat/route.ts
+++ b/backend/src/app/api/chat/route.ts
@@ -170,6 +170,7 @@ export async function POST(req: NextRequest) {
             response: aiResponse,
             status: status,
             chatId: targetChatId,
+            name: persona.name,
             debug: {
                 systemPrompt: systemInstruction,
                 userPrompt: message,

--- a/backend/src/app/api/chats/[id]/route.ts
+++ b/backend/src/app/api/chats/[id]/route.ts
@@ -62,11 +62,21 @@ export async function GET(
         // 初回取得時（カーソルなし）のみ内省結果とステータスを返す
         let latestReflection = null;
         let status = null;
+        let userMessageCountSinceLastReflection = 0;
 
         if (!cursor) {
             const reflectionEvent = await prisma.reflectionEvent.findFirst({
                 where: { personaId: chat.personaId },
                 orderBy: { createdAt: 'desc' }
+            });
+
+            // 最後の内省以降のユーザーメッセージ数をカウント（内省が一度もない場合は全件）
+            userMessageCountSinceLastReflection = await prisma.chatLog.count({
+                where: {
+                    chatId: id,
+                    role: 'user',
+                    ...(reflectionEvent ? { createdAt: { gt: reflectionEvent.createdAt } } : {})
+                }
             });
 
             if (reflectionEvent) {
@@ -88,6 +98,7 @@ export async function GET(
             nextCursor,
             latestReflection,
             status,
+            userMessageCountSinceLastReflection,
         });
     } catch (error: any) {
         return NextResponse.json({ error: error.message }, { status: 500 });

--- a/backend/src/app/api/chats/[id]/route.ts
+++ b/backend/src/app/api/chats/[id]/route.ts
@@ -26,7 +26,7 @@ export async function GET(
 
         const chat = await prisma.chat.findUnique({
             where: { id },
-            select: { id: true, title: true, personaId: true, createdAt: true, updatedAt: true }
+            select: { id: true, title: true, personaId: true, additionalPersonaId: true, options: true, createdAt: true, updatedAt: true }
         });
 
         if (!chat) {
@@ -39,6 +39,7 @@ export async function GET(
             where: { chatId: id },
             orderBy: { createdAt: 'desc' },
             take: take + 1, // 次ページの有無を判定するために1件多く取得
+            include: { persona: { select: { name: true } } },
             ...(cursor ? {
                 cursor: { id: cursor },
                 skip: 1, // カーソル自体はスキップする
@@ -115,15 +116,20 @@ export async function PATCH(
     try {
         const { id } = await params;
         const body = await req.json();
-        const { title } = body;
+        const { title, additionalPersonaId, options } = body;
 
-        if (!title) {
-            return NextResponse.json({ error: "Title is required" }, { status: 400 });
+        const data: any = {};
+        if (title !== undefined) data.title = title;
+        if (additionalPersonaId !== undefined) data.additionalPersonaId = additionalPersonaId;
+        if (options !== undefined) data.options = options;
+
+        if (Object.keys(data).length === 0) {
+            return NextResponse.json({ error: "No fields to update" }, { status: 400 });
         }
 
         const updatedChat = await prisma.chat.update({
             where: { id },
-            data: { title },
+            data,
         });
 
         return NextResponse.json(updatedChat);

--- a/backend/src/app/api/graph/route.ts
+++ b/backend/src/app/api/graph/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 export const dynamic = 'force-dynamic';
 
 /** タイムアウトのミリ秒数 */
-const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_TIMEOUT_MS = 30_000;
 
 /**
  * LLMサービスからグラフデータを取得するAPIエンドポイント。

--- a/backend/src/app/api/reflect/route.ts
+++ b/backend/src/app/api/reflect/route.ts
@@ -122,6 +122,26 @@ export async function POST(req: NextRequest) {
         }
         console.log(`[Reflect API] Found ${recentLogs.length} recent logs.`);
 
+        // 前回の内省からのユーザー発言回数をチェック (5回以上必要)
+        const reflectionEvent = await prisma.reflectionEvent.findFirst({
+            where: { personaId: personaId },
+            orderBy: { createdAt: 'desc' }
+        });
+        
+        const userMessageCountSinceLastReflection = await prisma.chatLog.count({
+            where: {
+                chatId: chatId,
+                role: 'user',
+                ...(reflectionEvent ? { createdAt: { gt: reflectionEvent.createdAt } } : {})
+            }
+        });
+
+        const REQUIRED_TURNS = 5;
+        if (userMessageCountSinceLastReflection < REQUIRED_TURNS) {
+            console.log(`[Reflect API] Not enough user messages since last reflection. Count: ${userMessageCountSinceLastReflection}, Required: ${REQUIRED_TURNS}`);
+            return NextResponse.json({ error: `内省を行うには、前回の内省から${REQUIRED_TURNS}回以上のユーザーの発言が必要です。(現在: ${userMessageCountSinceLastReflection}回)` }, { status: 400 });
+        }
+
         const logSummary = recentLogs.slice().reverse().map((l) => `${l.role}: ${l.content}`).join("\n");
 
         // 2. 現在のペルソナステータスを取得

--- a/backend/src/lib/llm.ts
+++ b/backend/src/lib/llm.ts
@@ -112,7 +112,7 @@ export function buildSystemInstruction(context: PersonaContext): string {
     const s = context.status;
     const growthDelta = context.growthDelta || 0;
 
-    let instruction = `あなたは自己進化型AI「${s.name || 'Reflecta'}」です。
+    let instruction = `あなたの名前は「${s.name || 'Reflecta'}」です。
 以下のステータスと記憶に基づいて、一貫性のある人格として振る舞ってください。
 
 【重要】

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -172,6 +172,10 @@ function App() {
   /** メインエリアのタブ状態: 'chat' | 'persona-log' | 'graph' */
   const [activeTab, setActiveTab] = useState<'chat' | 'persona-log' | 'graph'>('chat');
 
+  /** 内省頻度制限のためのステート */
+  const [userMessageCountSinceLastReflection, setUserMessageCountSinceLastReflection] = useState<number>(0);
+  const REQUIRED_TURNS = 5;
+
   // Load state from localStorage
   const [currentPersonaId, setCurrentPersonaId] = useState<string | null>(() => localStorage.getItem('currentPersonaId'));
   // currentChatId also needs to be persisted to restore session
@@ -318,6 +322,12 @@ function App() {
           setLastReflection(null);
         }
 
+        if (typeof res.data.userMessageCountSinceLastReflection === 'number') {
+            setUserMessageCountSinceLastReflection(res.data.userMessageCountSinceLastReflection);
+        } else {
+            setUserMessageCountSinceLastReflection(0);
+        }
+
         // ステータスがあればセット (初回ロード時など)
         if (res.data.status) {
           console.log('[App] Setting initial status:', res.data.status);
@@ -454,6 +464,7 @@ function App() {
       if (!currentChatId && res.data.chatId) {
         setCurrentChatId(res.data.chatId);
       }
+      setUserMessageCountSinceLastReflection(prev => prev + 1);
       const aiMsg: Message = { role: 'assistant', content: res.data.response, createdAt: new Date().toISOString() };
       setMessages(prev => [...prev, aiMsg]);
       if (res.data.status) setStatus(res.data.status);
@@ -500,6 +511,7 @@ function App() {
         createdAt: new Date().toISOString(),
         response: res.data.reflection
       });
+      setUserMessageCountSinceLastReflection(0);
 
       const followUpMessage = "内省が終わったようですね。今の気分はどうですか？";
       setMessages(prev => [...prev, { role: 'user', content: followUpMessage, createdAt: new Date().toISOString() }]);
@@ -785,10 +797,10 @@ function App() {
                   <div className="text-center mt-4 mb-2">
                     <button
                       onClick={handleReflect}
-                      disabled={isLoading}
-                      className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 text-xs font-semibold tracking-wide cursor-pointer disabled:cursor-not-allowed"
+                      disabled={isLoading || userMessageCountSinceLastReflection < REQUIRED_TURNS}
+                      className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 text-xs font-semibold tracking-wide cursor-pointer disabled:cursor-not-allowed group relative"
                     >
-                      内省を実行する
+                      {userMessageCountSinceLastReflection < REQUIRED_TURNS ? `内省を実行する (あと${REQUIRED_TURNS - userMessageCountSinceLastReflection}回)` : '内省を実行する'}
                     </button>
                   </div>
                 </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -385,6 +385,16 @@ function App() {
   }, [currentChatId, nextCursor, isLoadingMore, hasMore]);
 
   /**
+   * 現在のスクロール位置が最下部付近かチェックする
+   */
+  const checkScrollPosition = useCallback(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+    const distanceFromBottom = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
+    setIsNearBottom(distanceFromBottom < 150);
+  }, []);
+
+  /**
    * 最下部へスムーズスクロールする
    */
   const scrollToBottom = useCallback(() => {
@@ -393,8 +403,10 @@ function App() {
         top: scrollRef.current.scrollHeight,
         behavior: 'smooth'
       });
+      // スクロール開始後に判定を更新
+      setTimeout(checkScrollPosition, 500);
     }
-  }, []);
+  }, [checkScrollPosition]);
 
   /**
    * スクロールイベントハンドラ
@@ -410,29 +422,41 @@ function App() {
       if (scrollEl.scrollTop < 100 && hasMore && !isLoadingMore) {
         fetchOlderMessages();
       }
-      // 最下部付近にいるか判定（150px以内なら最下部とみなす）
-      const distanceFromBottom = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
-      setIsNearBottom(distanceFromBottom < 150);
+      checkScrollPosition();
     };
 
     scrollEl.addEventListener('scroll', handleScroll);
     return () => scrollEl.removeEventListener('scroll', handleScroll);
-  }, [hasMore, isLoadingMore, fetchOlderMessages]);
+  }, [hasMore, isLoadingMore, fetchOlderMessages, checkScrollPosition]);
 
-  /** 新しいメッセージが追加された場合のみ最下部にスクロール */
+  /** メッセージが追加・更新された場合のスクロール制御 */
   const prevMessageCountRef = useRef(0);
   useEffect(() => {
-    // メッセージ数が増えた場合（新規送信）のみ自動スクロール
-    // 古いメッセージの読み込み時はスクロールしない（fetchOlderMessages内で位置を維持済み）
-    if (messages.length > prevMessageCountRef.current && scrollRef.current) {
-      const isOlderMessageLoad = prevMessageCountRef.current === 0 ||
-        (messages.length - prevMessageCountRef.current <= 2);
-      if (isOlderMessageLoad || prevMessageCountRef.current === 0) {
+    // メッセージ数が増えた場合（新規送信や初回ロード）の制御
+    if (messages.length > 0 && scrollRef.current) {
+      if (prevMessageCountRef.current === 0) {
+        // 初回ロード時は最下部へ
         scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      } else if (messages.length > prevMessageCountRef.current) {
+        // 新規メッセージ追加時
+        const isOlderMessageLoad = messages.length - prevMessageCountRef.current > 2;
+        if (!isOlderMessageLoad) {
+          // 自分が送った、あるいは返信がきた場合は最下部へ
+          scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
       }
+      // メッセージ更新後にスクロール位置を再判定
+      setTimeout(checkScrollPosition, 100);
     }
     prevMessageCountRef.current = messages.length;
-  }, [messages]);
+  }, [messages, checkScrollPosition]);
+
+  /** タブ切り替え時にスクロール位置を再チェック */
+  useEffect(() => {
+    if (activeTab === 'chat') {
+      setTimeout(checkScrollPosition, 100);
+    }
+  }, [activeTab, checkScrollPosition]);
 
   const handleSend = async () => {
     if (!input.trim() || isLoading) return;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,6 +116,7 @@ function App() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isReflecting, setIsReflecting] = useState(false);
   const [status, setStatus] = useState<PersonaStatus>({
     height: 160,
     weight: 50,
@@ -483,7 +484,7 @@ function App() {
       return;
     }
 
-    setIsLoading(true);
+    setIsReflecting(true);
     try {
       const llmConfig = {
         provider: llmSettings.provider,
@@ -495,8 +496,8 @@ function App() {
         llmConfig,
         chatId: currentChatId
       });
-      toast.success(`内省完了: ${res.data.reflection.permanentMemory || "新たな気付きはありませんでした"}`, {
-        duration: 5000,
+      toast.success('内省が完了しました', {
+        duration: 3000,
         style: {
           background: '#10B981', // Emerald 500
           color: '#fff',
@@ -528,12 +529,12 @@ function App() {
     } catch (error) {
       handleApiError(error, '内省処理に失敗しました');
     } finally {
-      setIsLoading(false);
+      setIsReflecting(false);
     }
   };
 
   return (
-    <div className="flex flex-col h-screen w-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 overflow-hidden font-sans transition-colors duration-300">
+    <div className="flex flex-col h-screen w-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 overflow-hidden font-sans transition-colors duration-300 relative">
       <Toaster
         position="top-center"
         toastOptions={{
@@ -797,7 +798,7 @@ function App() {
                   <div className="text-center mt-4 mb-2">
                     <button
                       onClick={handleReflect}
-                      disabled={isLoading || userMessageCountSinceLastReflection < REQUIRED_TURNS}
+                      disabled={isLoading || isReflecting || userMessageCountSinceLastReflection < REQUIRED_TURNS}
                       className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-800 text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 text-xs font-semibold tracking-wide cursor-pointer disabled:cursor-not-allowed group relative"
                     >
                       {userMessageCountSinceLastReflection < REQUIRED_TURNS ? `内省を実行する (あと${REQUIRED_TURNS - userMessageCountSinceLastReflection}回)` : '内省を実行する'}
@@ -849,6 +850,31 @@ function App() {
           }}
         />
       </div>
+
+      {/* 画面全体を覆う内省用ローディングオーバーレイ */}
+      <AnimatePresence>
+        {isReflecting && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 backdrop-blur-sm"
+          >
+            <div className="flex flex-col items-center gap-4 p-8 bg-white/10 dark:bg-slate-900/40 rounded-3xl shadow-2xl border border-white/20 dark:border-slate-800/50 backdrop-blur-md">
+              <div className="relative">
+                <div className="w-16 h-16 border-4 border-indigo-500/30 rounded-full animate-pulse blur-sm absolute inset-0"></div>
+                <div className="w-16 h-16 border-4 border-slate-200 dark:border-slate-700 border-t-indigo-500 rounded-full animate-spin relative z-10"></div>
+              </div>
+              <p className="text-lg font-medium tracking-wider text-slate-800 dark:text-slate-100 mt-2">
+                人格再構築システムによる内省処理が進行中です
+              </p>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                この処理には数十秒かかる場合があります
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ interface Message {
   content: string;
   /** メッセージの送信日時 */
   createdAt?: string;
+  /** 話しているペルソナの名前 */
+  name?: string;
 }
 
 interface Persona {
@@ -309,7 +311,8 @@ function App() {
         const history = res.data.chatLogs.map((log: any) => ({
           role: log.role as 'user' | 'assistant',
           content: log.content,
-          createdAt: log.createdAt
+          createdAt: log.createdAt,
+          name: log.persona?.name
         }));
         setMessages(history);
         setNextCursor(res.data.nextCursor || null);
@@ -490,7 +493,7 @@ function App() {
         setCurrentChatId(res.data.chatId);
       }
       setUserMessageCountSinceLastReflection(prev => prev + 1);
-      const aiMsg: Message = { role: 'assistant', content: res.data.response, createdAt: new Date().toISOString() };
+      const aiMsg: Message = { role: 'assistant', content: res.data.response, createdAt: new Date().toISOString(), name: res.data.name };
       setMessages(prev => [...prev, aiMsg]);
       if (res.data.status) setStatus(res.data.status);
       if (res.data.debug) setLastDebugInfo(res.data.debug);
@@ -547,7 +550,7 @@ function App() {
         chatId: currentChatId,
         personaId: currentPersonaId
       });
-      setMessages(prev => [...prev, { role: 'assistant', content: resChat.data.response, createdAt: new Date().toISOString() }]);
+      setMessages(prev => [...prev, { role: 'assistant', content: resChat.data.response, createdAt: new Date().toISOString(), name: resChat.data.name }]);
       if (resChat.data.status) setStatus(resChat.data.status);
       setRefreshTrigger(prev => prev + 1);
     } catch (error) {
@@ -738,17 +741,20 @@ function App() {
                               }`}>
                               <p className="leading-relaxed whitespace-pre-wrap">{m.content}</p>
                             </div>
-                            {/* 時刻表示 (#14) */}
-                            {m.createdAt && (
-                              <span className={`text-[10px] text-slate-400 dark:text-slate-500 px-1 ${
-                                m.role === 'user' ? 'text-right' : 'text-left'
-                              }`}>
-                                {new Date(m.createdAt).toLocaleTimeString('ja-JP', {
-                                  hour: '2-digit',
-                                  minute: '2-digit',
-                                })}
-                              </span>
-                            )}
+                            {/* 時刻と名前表示 (#14, 複数ペルソナ対応) */}
+                            <div className={`flex items-center gap-2 px-1 text-[10px] text-slate-400 dark:text-slate-500 ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                              {m.role === 'assistant' && m.name && (
+                                <span className="font-semibold text-slate-500 dark:text-slate-400">{m.name}</span>
+                              )}
+                              {m.createdAt && (
+                                <span>
+                                  {new Date(m.createdAt).toLocaleTimeString('ja-JP', {
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                  })}
+                                </span>
+                              )}
+                            </div>
                           </div>
                         </motion.div>
                       );
@@ -851,6 +857,7 @@ function App() {
           onSelectChat={(id: string) => setCurrentChatId(id)}
           currentChatId={currentChatId}
           currentPersonaId={currentPersonaId}
+          personas={personas}
           onNewChat={() => setCurrentChatId(null)}
           chatModel={chatModel}
           setChatModel={setChatModel}

--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -4,10 +4,16 @@ import { MessageCircle, PlusCircle, Settings, CheckCircle, RefreshCw, ChevronDow
 import { motion, AnimatePresence } from 'framer-motion';
 import toast from 'react-hot-toast';
 
+interface Persona {
+    id: string;
+    name: string;
+}
+
 interface Chat {
     id: string;
     title: string;
     updatedAt: string;
+    additionalPersonaId?: string | null;
     _count?: {
         chatLogs: number;
     };
@@ -38,6 +44,7 @@ type ChatHistoryProps = {
     onSelectChat: (id: string) => void;
     currentChatId: string | null;
     currentPersonaId: string | null;
+    personas: Persona[];
     onNewChat: () => void;
     // LLM Settings
     chatModel: string;
@@ -86,6 +93,7 @@ export function ChatHistory({
     onSelectChat,
     currentChatId,
     currentPersonaId,
+    personas,
     onNewChat,
     chatModel,
     setChatModel,
@@ -102,6 +110,7 @@ export function ChatHistory({
     const [loadingModels, setLoadingModels] = useState(false);
     const [editingChatId, setEditingChatId] = useState<string | null>(null);
     const [editingTitle, setEditingTitle] = useState("");
+    const [showSettingsChatId, setShowSettingsChatId] = useState<string | null>(null);
     /** 本番環境では Local LLM UI を非表示にするためのフラグ */
     const [isLocalLLMEnabled, setIsLocalLLMEnabled] = useState(true);
 
@@ -143,6 +152,19 @@ export function ChatHistory({
             toast.error('Failed to update chat title');
         } finally {
             setEditingChatId(null);
+        }
+    };
+
+    const saveAdditionalPersona = async (chatId: string, additionalPersonaId: string) => {
+        try {
+            await axios.patch(`${API_URL}/api/chats/${chatId}`, { 
+                additionalPersonaId: additionalPersonaId || null 
+            });
+            setChats(chats.map(c => c.id === chatId ? { ...c, additionalPersonaId: additionalPersonaId || null } : c));
+            toast.success('Additional persona updated');
+        } catch (error) {
+            console.error('Failed to update additional persona:', error);
+            toast.error('Failed to update additional persona');
         }
     };
 
@@ -286,10 +308,34 @@ export function ChatHistory({
                                                 </h3>
                                             )}
                                         </div>
-                                        <span className="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap ml-2">
-                                            {formatDate(chat.updatedAt)}
-                                        </span>
+                                        <div className="flex items-center gap-1 ml-2">
+                                            <button
+                                                onClick={(e) => { e.stopPropagation(); setShowSettingsChatId(chat.id === showSettingsChatId ? null : chat.id); }}
+                                                className="p-1 hover:bg-slate-200 dark:hover:bg-slate-700 rounded text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                                                title="Chat Settings"
+                                            >
+                                                <Settings className="w-3.5 h-3.5" />
+                                            </button>
+                                            <span className="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap">
+                                                {formatDate(chat.updatedAt)}
+                                            </span>
+                                        </div>
                                     </div>
+                                    {showSettingsChatId === chat.id && (
+                                        <div className="mt-2 p-2 bg-white dark:bg-slate-800 rounded border border-slate-200 dark:border-slate-700" onClick={e => e.stopPropagation()}>
+                                            <label className="block text-[10px] uppercase font-bold text-slate-400 mb-1">Additional Persona</label>
+                                            <select
+                                                value={chat.additionalPersonaId || ""}
+                                                onChange={(e) => saveAdditionalPersona(chat.id, e.target.value)}
+                                                className="w-full bg-slate-50 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-2 py-1 text-xs text-slate-700 dark:text-slate-300"
+                                            >
+                                                <option value="">None</option>
+                                                {personas.filter(p => p.id !== currentPersonaId).map(p => (
+                                                    <option key={p.id} value={p.id}>{p.name}</option>
+                                                ))}
+                                            </select>
+                                        </div>
+                                    )}
                             </div>
                         ))
                     )}

--- a/frontend/src/components/GraphViewer.tsx
+++ b/frontend/src/components/GraphViewer.tsx
@@ -88,14 +88,64 @@ export const GraphViewer: React.FC = () => {
             <ForceGraph2D
                 ref={fgRef}
                 graphData={data}
-                nodeLabel="id"
-                nodeColor={node => node.group === 'Concept' ? '#4ade80' : '#60a5fa'}
                 nodeRelSize={6}
+                // ノードのカスタム描画（丸とラベルを常時表示）
+                nodeCanvasObject={(node: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
+                    const label = node.id;
+                    const fontSize = 12 / globalScale;
+                    ctx.font = `${fontSize}px Inter, Roboto, "Segoe UI", sans-serif`;
+                    const textWidth = ctx.measureText(label).width;
+                    const bckgDimensions = [textWidth, fontSize].map(n => n + fontSize * 0.2); // some padding
+
+                    // ノードの円
+                    ctx.beginPath();
+                    ctx.arc(node.x, node.y, 5, 0, 2 * Math.PI, false);
+                    ctx.fillStyle = node.group === 'Concept' ? '#4ade80' : '#60a5fa';
+                    ctx.fill();
+
+                    // テキストの背景（可読性向上のため）
+                    ctx.fillStyle = 'rgba(15, 23, 42, 0.6)';
+                    ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y + 7, bckgDimensions[0], bckgDimensions[1]);
+
+                    // テキスト
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillStyle = '#f8fafc';
+                    ctx.fillText(label, node.x, node.y + 7 + bckgDimensions[1] / 2);
+                }}
+                nodePointerAreaPaint={(node: any, color, ctx) => {
+                    ctx.fillStyle = color;
+                    ctx.beginPath(); ctx.arc(node.x, node.y, 5, 0, 2 * Math.PI, false); ctx.fill();
+                }}
+                // リンクのカスタム描画（ラベルを常時表示）
+                linkCanvasObjectMode={() => 'after'}
+                linkCanvasObject={(link: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
+                    const MAX_FONT_SIZE = 4;
+                    const LABEL_NODE_MARGIN = 6;
+
+                    const start = link.source;
+                    const end = link.target;
+
+                    // リンクの中間点を計算
+                    const textPos = Object.assign({}, ...['x', 'y'].map(c => ({
+                        [c]: start[c] + (end[c] - start[c]) / 2 // middle point
+                    })));
+
+                    const relSize = Math.sqrt(Math.pow(end.x - start.x, 2) + Math.pow(end.y - start.y, 2));
+                    const fontSize = Math.min(MAX_FONT_SIZE, (relSize - LABEL_NODE_MARGIN) / link.label.length);
+
+                    ctx.font = `${fontSize}px Sans-Serif`;
+                    ctx.fillStyle = link.is_personal ? '#fbbf24' : '#94a3b8';
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillText(link.label, textPos.x, textPos.y);
+                }}
                 linkColor={(link: any) => link.is_personal ? '#fbbf24' : '#94a3b8'}
-                linkWidth={(link: any) => link.weight ? link.weight * 2 : 1}
-                linkLabel={(link: any) => `${link.label} (w=${link.weight})`}
-                linkDirectionalArrowLength={3.5}
+                linkWidth={(link: any) => (link.weight ? link.weight * 2 : 1.5)}
+                linkDirectionalArrowLength={8} // 矢印を大きく
                 linkDirectionalArrowRelPos={1}
+                linkDirectionalParticles={2} // 流れを強調
+                linkDirectionalParticleSpeed={0.005}
                 onEngineStop={handleEngineStop}
                 width={dimensions.width}
                 height={dimensions.height}

--- a/llm-service/chains/chat.py
+++ b/llm-service/chains/chat.py
@@ -108,7 +108,7 @@ def build_system_instruction(context: ChatContext) -> str:
     s = context.status
     growth_delta = context.growth_delta
 
-    instruction = f"""あなたは自己進化型AI「{s.name}」です。
+    instruction = f"""あなたの名前は「{s.name}」です。
 以下のステータスと記憶に基づいて、一貫性のある人格として振る舞ってください。
 
 【重要】

--- a/llm-service/chains/reflection.py
+++ b/llm-service/chains/reflection.py
@@ -24,7 +24,7 @@ class ReflectionResult(BaseModel):
 def create_reflection_chain(llm: BaseChatModel):
     prompt = ChatPromptTemplate.from_messages([
         ("system", """
-あなたは自己進化型AI「{name}」です。
+あなたの名前は「{name}」です。
 以下の情報に基づいて自己分析を行い、あなた自身のステータスがどのように変化すべきかを判断してください。
 
 ### 分析対象の会話履歴:

--- a/llm-service/main.py
+++ b/llm-service/main.py
@@ -144,7 +144,7 @@ async def reflect(request: ReflectionRequest):
         # ステータス情報の展開
         s = request.status
         
-        result = chain.invoke({
+        result = await chain.ainvoke({
             "name": s.name or "Reflecta",
             "log_summary": request.log_summary,
             "gender": s.gender or "不明",
@@ -185,4 +185,18 @@ async def reflect(request: ReflectionRequest):
 @app.get("/graph")
 async def get_graph():
     """ナレッジグラフ全体を取得するエンドポイント"""
-    return graph_service.get_whole_graph()
+    import time
+    start_time = time.time()
+    print("[Graph] Fetching whole graph...")
+    try:
+        result = graph_service.get_whole_graph()
+        duration = time.time() - start_time
+        print(f"[Graph] Successfully fetched graph in {duration:.3f}s")
+        return result
+    except Exception as e:
+        duration = time.time() - start_time
+        print(f"[Graph] Failed to fetch graph after {duration:.3f}s: {e}")
+        import traceback
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+

--- a/llm-service/tests/test_reflect.py
+++ b/llm-service/tests/test_reflect.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 import sys
 import os
 import json
@@ -41,7 +41,8 @@ def test_reflect_endpoint():
                 
                 # Chainインスタンスのモック
                 mock_chain_instance = MagicMock()
-                mock_chain_instance.invoke.return_value = mock_result
+                # ainvoke を AsyncMock でモック化する
+                mock_chain_instance.ainvoke = AsyncMock(return_value=mock_result)
                 mock_create_chain.return_value = mock_chain_instance
 
                 # 3. リクエストデータ (JS側から送られるJSONを模倣)


### PR DESCRIPTION
Close: https://github.com/mshirai0327/self-reflection-chatbot/issues/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Overview: グラフ表示改善、マルチペルソナ

## 変更の主目的

1. **内省の多重実行防止** — Issue #56 対応
   - 内省実行前に、直近のユーザーメッセージ数が5ターン以上であることを確認する条件を追加
   - 不要なAPI呼び出し（課金・レート消費）を防止

2. **マルチペルソナ対応**
   - チャットに主ペルソナ（personaId）と追加ペルソナ（additionalPersonaId）の二者を関連付け可能に拡張
   - フロントエンドで追加ペルソナを選択・管理するUI機能を追加

3. **グラフ表示の改善**
   - グラフノード・リンクのカスタムキャンバス描画を実装（ラベル、色付け、矢印、パーティクル効果）
   - より直感的で可視化された知識グラフ表示

4. **グラフAPI・LLMサービスの安定性向上**
   - グラフ取得タイムアウトを 10秒 → 30秒 に延長
   - 反映処理の非同期化で LLM イベントループのブロック解消

---

## 影響範囲

### データベース層
- **backend/prisma/schema.prisma**
  - `Chat` モデル: `personaId` + `additionalPersonaId` で二者のペルソナ関連付けに対応
  - `Chat` モデル: `options` フィールド追加（メタデータ）
  - `Persona` モデル: 二つのリレーション (`chats`, `additionalChats`) に分離

### バックエンド API
- **backend/src/app/api/reflect/route.ts** — ユーザーメッセージ数カウント & 5ターン未満でエラー返却
- **backend/src/app/api/chats/[id]/route.ts** — `additionalPersonaId`, `options`, `userMessageCountSinceLastReflection` の取得・更新に対応
- **backend/src/app/api/chat/route.ts** — レスポンスに `persona.name` を追加
- **backend/src/app/api/graph/route.ts** — タイムアウト延長（10s → 30s）

### LLMサービス層
- **llm-service/chains/chat.py** — システム指示の文言調整（「自己進化型AI」→「名前は」）
- **llm-service/chains/reflection.py** — 同様に文言調整
- **llm-service/main.py** — 反映処理を非同期化 (`invoke` → `ainvoke`)、グラフ取得にエラーハンドリング・ログ追加
- **llm-service/tests/test_reflect.py** — 非同期テストへの対応

### フロントエンド
- **frontend/src/App.tsx** — Message モデルに `name` フィールド追加、内省実行の状態管理（`isReflecting`, `userMessageCountSinceLastReflection`）、反映後の自動返信、全画面ローディングオーバーレイ実装
- **frontend/src/components/ChatHistory.tsx** — チャット単位で追加ペルソナを選択・変更するUI（セッティングパネル、ドロップダウン）追加
- **frontend/src/components/GraphViewer.tsx** — カスタムキャンバスレンダリング導入（ノード・リンク描画、ラベル、矢印、パーティクル）

---

## 影響するモジュール数
- バックエンド: 5ファイル
- LLMサービス: 4ファイル  
- フロントエンド: 3ファイル
- データベーススキーマ: 1ファイル

**合計: 13ファイル**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->